### PR TITLE
Flesh out network error

### DIFF
--- a/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
+++ b/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
@@ -1,5 +1,6 @@
 module Graphql = ApolloClient__Graphql;
 module GraphQLError = ApolloClient__Graphql.Error.GraphQLError;
+module LinkError = ApolloClient__LinkError;
 
 module Js_ = {
   // export declare class ApolloError extends Error {
@@ -11,7 +12,8 @@ module Js_ = {
   type t = {
     extraInfo: Js.Json.t,
     graphQLErrors: array(Graphql.Error.GraphQLError.t),
-    networkError: Js.nullable(Js.Exn.t),
+    networkError:
+      Js.nullable(LinkError.ErrorResponse.Js_.NetworkErrorUnion.t),
     // ...extends Error
     name: string,
     message: string,
@@ -20,7 +22,8 @@ module Js_ = {
 
   type make_args = {
     graphQLErrors: option(array(GraphQLError.t)),
-    networkError: Js.nullable(Js.Exn.t),
+    networkError:
+      Js.nullable(LinkError.ErrorResponse.Js_.NetworkErrorUnion.t),
     errorMessage: option(string),
     extraInfo: option(Js.Json.t),
   };
@@ -35,7 +38,29 @@ module Js_ = {
   external make: make_args => t = "ApolloError";
 };
 
-type t = Js_.t;
+type t = {
+  extraInfo: Js.Json.t,
+  graphQLErrors: array(Graphql.Error.GraphQLError.t),
+  networkError: option(LinkError.ErrorResponse.t_networkError),
+  name: string,
+  message: string,
+  stack: option(string),
+};
+
+let fromJs: Js_.t => t =
+  js => {
+    extraInfo: js.extraInfo,
+    graphQLErrors: js.graphQLErrors,
+    networkError:
+      js.networkError
+      ->Js.toOption
+      ->Belt.Option.map(
+          LinkError.ErrorResponse.Js_.NetworkErrorUnion.classify,
+        ),
+    name: js.name,
+    message: js.message,
+    stack: js.stack,
+  };
 
 let make:
   (
@@ -49,7 +74,13 @@ let make:
   (~graphQLErrors=?, ~networkError=?, ~errorMessage=?, ~extraInfo=?, ()) =>
     Js_.make({
       graphQLErrors,
-      networkError: Js.Nullable.fromOption(networkError),
+      networkError:
+        Js.Nullable.fromOption(
+          networkError->Belt.Option.map(
+            LinkError.ErrorResponse.Js_.NetworkErrorUnion.error,
+          ),
+        ),
       errorMessage,
       extraInfo,
-    });
+    })
+    ->fromJs;

--- a/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
+++ b/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
@@ -1,6 +1,8 @@
 module Graphql = ApolloClient__Graphql;
 module GraphQLError = ApolloClient__Graphql.Error.GraphQLError;
 module LinkError = ApolloClient__LinkError;
+module ServerError = ApolloClient__Link_Utils_ThrowServerError.ServerError;
+module ServerParseError = ApolloClient__Link_Http_ParseAndCheckHttpResponse.ServerParseError;
 
 module Js_ = {
   // export declare class ApolloError extends Error {
@@ -37,6 +39,15 @@ module Js_ = {
   [@bs.module "@apollo/client"] [@bs.new]
   external make: make_args => t = "ApolloError";
 };
+
+type t_networkError =
+  LinkError.ErrorResponse.t_networkError =
+    // This is a catch-all for any error coming from a fetch call that is not the other two
+    | Error(Js.Exn.t)
+    // ServerError means you got a bad code
+    | ServerError(ServerError.t)
+    // ServerParseError means apollo couldn't JSON.parse the body
+    | ServerParseError(ServerParseError.t);
 
 type t = {
   extraInfo: Js.Json.t,

--- a/src/@apollo/client/link/http/ApolloClient__Link_Http_ParseAndCheckHttpResponse.re
+++ b/src/@apollo/client/link/http/ApolloClient__Link_Http_ParseAndCheckHttpResponse.re
@@ -24,4 +24,6 @@ module ServerParseError = {
       stack: option(string),
     };
   };
+
+  type t = Js_.t;
 };

--- a/src/@apollo/client/link/utils/ApolloClient__Link_Utils_ThrowServerError.re
+++ b/src/@apollo/client/link/utils/ApolloClient__Link_Utils_ThrowServerError.re
@@ -19,4 +19,6 @@ module ServerError = {
       stack: option(string),
     };
   };
+
+  type t = Js_.t;
 };

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
@@ -39,7 +39,7 @@ type useSubscription_result('data, 'variables) = {
   variables: option('variables),
   loading: bool,
   data: option('data),
-  error: option(ApolloError.Js_.t),
+  error: option(ApolloError.t),
 };
 
 let useSubscription:
@@ -91,7 +91,8 @@ let useSubscription:
           variables: jsSubscriptionResult.variables,
           loading: jsSubscriptionResult.loading,
           data: jsSubscriptionResult.data->Belt.Option.map(Operation.parse),
-          error: jsSubscriptionResult.error,
+          error:
+            jsSubscriptionResult.error->Belt.Option.map(ApolloError.fromJs),
         },
       jsSubscriptionResult,
     );

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -23,7 +23,7 @@ module QueryHookOptions = {
       displayName: option(string),
       skip: option(bool),
       onCompleted: option('jsData => unit),
-      onError: option(ApolloError.t => unit),
+      onError: option((. ApolloError.Js_.t) => unit),
       // ..extends BaseQueryOptions
       client: option(ApolloClient.t),
       context: option(Js.Json.t), // ACTUAL: Record<string, any>
@@ -71,7 +71,11 @@ module QueryHookOptions = {
     onCompleted:
       t.onCompleted
       ->Belt.Option.map((onCompleted, jsData) => onCompleted(jsData->parse)),
-    onError: t.onError,
+    onError:
+      t.onError
+      ->Belt.Option.map(onError =>
+          (. jsApolloError) => onError(ApolloError.fromJs(jsApolloError))
+        ),
     fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
     notifyOnNetworkStatusChange: t.notifyOnNetworkStatusChange,
     query: t.query,
@@ -98,7 +102,7 @@ module LazyQueryHookOptions = {
       [@bs.optional]
       onCompleted: 'jsData => unit,
       [@bs.optional]
-      onError: ApolloError.t => unit,
+      onError: (. ApolloError.Js_.t) => unit,
       // ..extends BaseQueryOptions
       [@bs.optional]
       client: ApolloClient.t,
@@ -157,7 +161,11 @@ module LazyQueryHookOptions = {
         ->Belt.Option.map((onCompleted, jsData) =>
             onCompleted(jsData->parse)
           ),
-      ~onError=?t.onError,
+      ~onError=?
+        t.onError
+        ->Belt.Option.map(onError =>
+            (. jsApolloError) => onError(ApolloError.fromJs(jsApolloError))
+          ),
       ~fetchPolicy=?
         t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
       ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
@@ -220,7 +228,7 @@ module QueryResult = {
       called: bool,
       client: ApolloClient.t,
       data: option('jsData),
-      error: option(ApolloError.t),
+      error: option(ApolloError.Js_.t),
       loading: bool,
       networkStatus: NetworkStatus.t,
       // ...extends ObservableQueryFields
@@ -266,7 +274,7 @@ module QueryResult = {
       called: js.called,
       client: js.client,
       data: js.data->Belt.Option.map(parse),
-      error: js.error,
+      error: js.error->Belt.Option.map(ApolloError.fromJs),
       fetchMore:
         (~context=?, ~variables=?, ~updateQuery as jsUpdateQuery=?, ()) => {
         js.fetchMore({
@@ -511,7 +519,7 @@ module MutationHookOptions = {
       [@bs.optional]
       notifyOnNetworkStatusChange: bool,
       [@bs.optional]
-      onError: ApolloError.Js_.t => unit,
+      onError: (. ApolloError.Js_.t) => unit,
       [@bs.optional]
       optimisticResponse: 'variables => 'jsData,
       [@bs.optional]
@@ -559,7 +567,12 @@ module MutationHookOptions = {
         ~ignoreResults=?t.ignoreResults,
         ~mutation=?t.mutation,
         ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
-        ~onError=?t.onError,
+        ~onError=?
+          t.onError
+          ->Belt.Option.map(onError =>
+              (. jsApolloError) =>
+                onError(ApolloError.fromJs(jsApolloError))
+            ),
         ~optimisticResponse=?
           t.optimisticResponse
           ->Belt.Option.map((optimisticResponse, variables) =>
@@ -603,7 +616,7 @@ module MutationResult = {
   let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
     (js, ~parse) => {
       data: js.data->Js.toOption->Belt.Option.map(parse),
-      error: js.error,
+      error: js.error->Belt.Option.map(ApolloError.fromJs),
       loading: js.loading,
       called: js.called,
       client: js.client,
@@ -827,14 +840,14 @@ module SubscriptionResult = {
   type t('data) = {
     loading: bool,
     data: option('data),
-    error: option(ApolloError.Js_.t),
+    error: option(ApolloError.t),
   };
 
   let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
     (js, ~parse) => {
       loading: js.loading,
       data: js.data->Belt.Option.map(parse),
-      error: js.error,
+      error: js.error->Belt.Option.map(ApolloError.fromJs),
     };
 };
 

--- a/src/@apollo/link-error/ApolloClient__LinkError.re
+++ b/src/@apollo/link-error/ApolloClient__LinkError.re
@@ -5,11 +5,13 @@ module NextLink = ApolloClient__Link_Core_Types.NextLink;
 module Operation = ApolloClient__Link_Core_Types.Operation;
 module ServerError = ApolloClient__Link_Utils_ThrowServerError.ServerError;
 module ServerParseError = ApolloClient__Link_Http_ParseAndCheckHttpResponse.ServerParseError;
+
 // export declare class ErrorLink extends ApolloLink {
 //     private link;
 //     constructor(errorHandler: ErrorLink.ErrorHandler);
 //     request(operation: Operation, forward: NextLink): Observable<FetchResult> | null;
 // }
+
 module ErrorResponse = {
   // export interface ErrorResponse {
   //     graphQLErrors?: ReadonlyArray<GraphQLError>;
@@ -41,35 +43,54 @@ module ErrorResponse = {
         | ServerError(ServerError.Js_.t)
         | ServerParseError(ServerParseError.Js_.t);
       let classify = (Any(v): t): case =>
-        if ([%raw {|function (value) { return "bodyText" in value}|}](v)) {
-          ServerParseError(Obj.magic(v): ServerParseError.Js_.t);
-        } else if ([%raw {|function (value) { return "result" in value}|}](v)) {
+        if ([%raw
+              {|function (v) { return "bodyText" in v && "response" in v && "statusCode" in v}|}
+            ](
+              v,
+            )) {
+          ServerError(Obj.magic(v): ServerError.Js_.t);
+        } else if ([%raw
+                     {|function (v) { return "result" in v && "response" in v && "statusCode" in v}|}
+                   ](
+                     v,
+                   )) {
           ServerParseError(Obj.magic(v): ServerParseError.Js_.t);
         } else {
           Error(Obj.magic(v): Js.Exn.t);
         };
     };
+
     type t = {
       graphQLErrors: option(array(GraphQLError.t)),
-      networkError: NetworkErrorUnion.t,
-      response: ExecutionResult.Js_.t(Js.Json.t),
+      networkError: option(NetworkErrorUnion.t),
+      response: option(ExecutionResult.Js_.t(Js.Json.t)),
       operation: Operation.Js_.t,
       forward: NextLink.Js_.t,
     };
   };
 
+  type t_networkError =
+    Js_.NetworkErrorUnion.case =
+      // This is a catch-all for any error coming from a fetch call that is not the other two
+      | Error(Js.Exn.t)
+      // ServerError means you got a bad code
+      | ServerError(ServerError.Js_.t)
+      // ServerParseError means apollo couldn't JSON.parse the body
+      | ServerParseError(ServerParseError.Js_.t);
+
   type t = {
     graphQLErrors: option(array(GraphQLError.t)),
-    networkError: Js_.NetworkErrorUnion.case,
-    response: ExecutionResult.Js_.t(Js.Json.t),
-    operation: Operation.Js_.t,
-    forward: NextLink.Js_.t,
+    networkError: option(t_networkError),
+    response: option(ExecutionResult.t(Js.Json.t)),
+    operation: Operation.t,
+    forward: NextLink.t,
   };
 
   let fromJs: Js_.t => t =
     js => {
       graphQLErrors: js.graphQLErrors,
-      networkError: js.networkError->Js_.NetworkErrorUnion.classify,
+      networkError:
+        js.networkError->Belt.Option.map(Js_.NetworkErrorUnion.classify),
       response: js.response,
       operation: js.operation,
       forward: js.forward,

--- a/src/@apollo/link-error/ApolloClient__LinkError.re
+++ b/src/@apollo/link-error/ApolloClient__LinkError.re
@@ -74,9 +74,9 @@ module ErrorResponse = {
       // This is a catch-all for any error coming from a fetch call that is not the other two
       | Error(Js.Exn.t)
       // ServerError means you got a bad code
-      | ServerError(ServerError.Js_.t)
+      | ServerError(ServerError.t)
       // ServerParseError means apollo couldn't JSON.parse the body
-      | ServerParseError(ServerParseError.Js_.t);
+      | ServerParseError(ServerParseError.t);
 
   type t = {
     graphQLErrors: option(array(GraphQLError.t)),


### PR DESCRIPTION
Apollo types the `networkError` property on `ApolloError` as `Error | null` which is kinda tragic. This is my initial exploration at fleshing things out. In an ideal world, network error would be something like this: https://github.com/elm/http/blob/2.0.0/src/Http.elm#L538
```
type Error
  = BadUrl String
  | Timeout
  | NetworkError
  | BadStatus Int
  | BadBody String
```

Unfortunately we don't have much ability to get this information after the fact. The types in `@apollo/link-error` are better: `Error | ServerError | ServerParseError` So tried working with that. It's wasn't clear to me from those names what they actually mean without digging into the internals of Apollo. If I were to rename them I'd do something like this: 
```
type networkError =
| FetchFailure(Js.Exn.t)
| BadStatus(int, ServerError.t)
| BadBody(ServerParseError.t)
```

Right now, I've messily pulled the types from the `link-error` bindings over and kept the names of the variants the same (`Error | ServerError | ServerParseError`), but I'm curious what anyone thinks of renaming the variants. This is one of the first cases where we're diverging from the TypeScript types, so I'm actually leaning that direction.