### PR TITLE
Add watchQuery

### DIFF
--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -11,6 +11,7 @@ module FetchResult = ApolloClient__Link_Core_Types.FetchResult;
 module MutationOptions = ApolloClient__Core_WatchQueryOptions.MutationOptions;
 module MutationQueryReducersMap = ApolloClient__Core_WatchQueryOptions.MutationQueryReducersMap;
 module MutationUpdaterFn = ApolloClient__Core_WatchQueryOptions.MutationUpdaterFn;
+module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
 module QueryOptions = ApolloClient__Core_WatchQueryOptions.QueryOptions;
 module PureQueryOptions = ApolloClient__Core_Types.PureQueryOptions;
 module RefetchQueryDescription = ApolloClient__Core_WatchQueryOptions.RefetchQueryDescription;
@@ -19,7 +20,7 @@ module UriFunction = ApolloClient__Link_Http_SelectHttpOptionsAndBody.UriFunctio
 module Types = ApolloClient__Types;
 module Utils = ApolloClient__Utils;
 module WatchQueryFetchPolicy = ApolloClient__Core_WatchQueryOptions.WatchQueryFetchPolicy;
-module WatchQueryOptions = ApolloClient__Core_WatchQueryOptions.QueryOptions;
+module WatchQueryOptions = ApolloClient__Core_WatchQueryOptions.WatchQueryOptions;
 
 module type Operation = Types.Operation;
 module type OperationNoRequiredVars = Types.OperationNoRequiredVars;
@@ -274,7 +275,6 @@ module Js_ = {
   //     private clearStoreCallbacks;
   //     private localState;
   //     stop(): void;
-  //     watchQuery<T = any, TVariables = OperationVariables>(options: WatchQueryOptions<TVariables>): ObservableQuery<T, TVariables>;
   //     subscribe<T = any, TVariables = OperationVariables>(options: SubscriptionOptions<TVariables>): Observable<FetchResult<T>>;
   //     readFragment<T = any, TVariables = OperationVariables>(options: DataProxy.Fragment<TVariables>, optimistic?: boolean): T | null;
   //     writeFragment<TData = any, TVariables = OperationVariables>(options: DataProxy.WriteFragmentOptions<TData, TVariables>): void;
@@ -291,6 +291,7 @@ module Js_ = {
   //     setResolvers(resolvers: Resolvers | Resolvers[]): void;
   //     getResolvers(): Resolvers;
   //     setLocalStateFragmentMatcher(fragmentMatcher: FragmentMatcher): void;
+  //     setLink(newLink: ApolloLink): void;
   // }
   type t;
   // mutate<T = any, TVariables = OperationVariables>(options: MutationOptions<T, TVariables>): Promise<FetchResult<T>>;
@@ -317,6 +318,13 @@ module Js_ = {
     ) =>
     Js.nullable('jsData) =
     "readQuery";
+
+  // <T = any, TVariables = OperationVariables>(options: WatchQueryOptions<TVariables>): ObservableQuery<T, TVariables>;
+  [@bs.send]
+  external watchQuery:
+    (t, ~options: WatchQueryOptions.Js_.t('variables)) =>
+    ObservableQuery.Js_.t('jsData) =
+    "watchQuery";
 
   // writeQuery<TData = any, TVariables = OperationVariables>(options: DataProxy.WriteQueryOptions<TData, TVariables>): void;
   [@bs.send]
@@ -515,6 +523,40 @@ let readQuery:
     )
     ->Js.toOption
     ->Belt.Option.map(Operation.parse);
+  };
+
+let watchQuery:
+  type data jsVariables.
+    (
+      t,
+      ~query: (module Operation with
+                 type t = data and type Raw.t_variables = jsVariables),
+      ~context: Js.Json.t=?,
+      ~errorPolicy: ErrorPolicy.t=?,
+      ~fetchPolicy: WatchQueryFetchPolicy.t=?,
+      jsVariables
+    ) =>
+    ObservableQuery.t(data) =
+  (
+    client,
+    ~query as (module Operation),
+    ~context=?,
+    ~errorPolicy=?,
+    ~fetchPolicy=?,
+    variables,
+  ) => {
+    Js_.watchQuery(
+      client,
+      ~options=
+        WatchQueryOptions.toJs({
+          fetchPolicy,
+          query: Operation.query,
+          variables: Some(variables),
+          errorPolicy,
+          context,
+        }),
+    )
+    ->ObservableQuery.fromJs(~parse=Operation.parse);
   };
 
 let writeQuery:

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
@@ -1,0 +1,125 @@
+module ApolloQueryResult = ApolloClient__Core_Types.ApolloQueryResult;
+module Subscription = ApolloClient__ZenObservable.Subscription;
+module Observer = ApolloClient__ZenObservable.Observer;
+
+module ObservableQuery = {
+  module Js_ = {
+    // export declare class ObservableQuery<TData = any, TVariables = OperationVariables> extends Observable<ApolloQueryResult<TData>> {
+    //     readonly options: WatchQueryOptions<TVariables>;
+    //     readonly queryId: string;
+    //     readonly queryName?: string;
+    //     get variables(): TVariables | undefined;
+    //     private isTornDown;
+    //     private queryManager;
+    //     private observers;
+    //     private subscriptions;
+    //     private lastResult;
+    //     private lastResultSnapshot;
+    //     private lastError;
+    //     constructor({ queryManager, options, }: {
+    //         queryManager: QueryManager<any>;
+    //         options: WatchQueryOptions<TVariables>;
+    //     });
+    //     result(): Promise<ApolloQueryResult<TData>>;
+    //     getCurrentResult(): ApolloCurrentQueryResult<TData>;
+    //     isDifferentFromLastResult(newResult: ApolloQueryResult<TData>): boolean;
+    //     getLastResult(): ApolloQueryResult<TData>;
+    //     getLastError(): ApolloError;
+    //     resetLastResults(): void;
+    //     resetQueryStoreErrors(): void;
+    //     refetch(variables?: Partial<TVariables>): Promise<ApolloQueryResult<TData>>;
+    //     fetchMore<K extends keyof TVariables>(fetchMoreOptions: FetchMoreQueryOptions<TVariables, K> & FetchMoreOptions<TData, TVariables>): Promise<ApolloQueryResult<TData>>;
+    //     subscribeToMore<TSubscriptionData = TData, TSubscriptionVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData>): () => void;
+    //     setOptions(newOptions: Partial<WatchQueryOptions<TVariables>>): Promise<ApolloQueryResult<TData>>;
+    //     setVariables(variables: TVariables): Promise<ApolloQueryResult<TData> | void>;
+    //     updateQuery<TVars = TVariables>(mapFn: (previousQueryResult: TData, options: Pick<WatchQueryOptions<TVars>, "variables">) => TData): void;
+    //     private getCurrentQueryResult;
+    //     startPolling(pollInterval: number): void;
+    //     stopPolling(): void;
+    //     private updateLastResult;
+    //     private onSubscribe;
+    //     private reobserver?;
+    //     private getReobserver;
+    //     private newReobserver;
+    //     reobserve(newOptions?: Partial<WatchQueryOptions<TVariables>>, newNetworkStatus?: NetworkStatus): Promise<ApolloQueryResult<TData>>;
+    //     private observer;
+    //     private tearDownQuery;
+    // }
+    type t('jsData);
+
+    // ...extends Observable<ApolloQueryResult<TData>>
+    // <R>(callback: (value: T) => R): Observable<R>;
+    [@bs.send] external map: (t('t), 't => 'r) => t('r) = "map";
+
+    // ...extends Observable<ApolloQueryResult<TData>>
+    // (onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
+    [@bs.send]
+    external subscribe:
+      (
+        t('jsData),
+        ~onNext: ApolloQueryResult.Js_.t('jsData) => unit,
+        ~onError: Js.Json.t => unit=?,
+        ~onComplete: unit => unit=?,
+        unit
+      ) =>
+      Subscription.Js_.t =
+      "subscribe";
+  };
+
+  type t('data);
+
+  external castFromJs: Js_.t('data) => t('data) = "%identity";
+
+  external castToJs: t('data) => Js_.t('data) = "%identity";
+
+  let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
+    (js, ~parse) => {
+      // Lovely. We should be able to just map, but it's broken:
+      // https://github.com/apollographql/apollo-client/issues/6144
+      // js->Js_.map(ApolloQueryResult.fromJs(~parse))->castFromJs;
+      [%raw
+        {|
+          function (js, parse) {
+            var originalSubscribe = js.subscribe.bind(js);
+            js.subscribe = function (onNext, onError, onComplete) {
+              var newOnNext = function (result) {
+                var parsedResult = result.data
+                  ? Object.assign({}, result, { data: parse(result.data) })
+                  : result;
+                return onNext(parsedResult);
+              };
+              originalSubscribe(newOnNext, onError, onComplete);
+            };
+            return js;
+          }
+        |}
+      ](
+        js,
+        parse,
+      );
+    };
+
+  [@bs.send] external map: (t('a), 'a => 'b) => t('b) = "map";
+
+  let subscribe:
+    (
+      t('data),
+      ~onNext: ApolloQueryResult.t('data) => unit,
+      ~onError: Js.Json.t => unit=?,
+      ~onComplete: unit => unit=?,
+      unit
+    ) =>
+    Subscription.t =
+    (t, ~onNext, ~onError=?, ~onComplete=?, ()) =>
+      /**
+       * Ugh, this diverges from normal patterns because data in these callbacks has to be parsed before this point.
+       * I wonder if there is a way we could pass parse along and then use it here or maybe there is a better pattern for this.
+       */
+      Js_.subscribe(
+        t->castToJs,
+        ~onNext=Obj.magic(onNext),
+        ~onError?,
+        ~onComplete?,
+        (),
+      );
+};

--- a/src/@apollo/client/utilities/observables/ApolloClient__Utilities_Observables.re
+++ b/src/@apollo/client/utilities/observables/ApolloClient__Utilities_Observables.re
@@ -1,0 +1,1 @@
+module Observable = ApolloClient__Utilities_Observables_Observable;

--- a/src/@apollo/client/utilities/observables/ApolloClient__Utilities_Observables_Observable.re
+++ b/src/@apollo/client/utilities/observables/ApolloClient__Utilities_Observables_Observable.re
@@ -1,0 +1,1 @@
+module Observable = ApolloClient__ZenObservable.Observable;

--- a/src/Jeddeloh__ApolloClient.re
+++ b/src/Jeddeloh__ApolloClient.re
@@ -53,6 +53,8 @@ module React = {
 
 module Utilities = ApolloClient__Utilities;
 
+module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
+
 module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions;
 module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions;
 module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions;
@@ -63,4 +65,5 @@ let make = ApolloClient__ApolloClient.make;
 let mutate = ApolloClient__ApolloClient.mutate;
 let query = ApolloClient__ApolloClient.query;
 let readQuery = ApolloClient__ApolloClient.readQuery;
+let watchQuery = ApolloClient__ApolloClient.watchQuery;
 let writeQuery = ApolloClient__ApolloClient.writeQuery;

--- a/src/zen-observable/ApolloClient__ZenObservable.re
+++ b/src/zen-observable/ApolloClient__ZenObservable.re
@@ -1,35 +1,49 @@
-module ZenObservable = {
-  // interface SubscriptionObserver<T> {
-  //     closed: boolean;
-  //     next(value: T): void;
-  //     error(errorValue: any): void;
-  //     complete(): void;
-  // }
+// interface SubscriptionObserver<T> {
+//     closed: boolean;
+//     next(value: T): void;
+//     error(errorValue: any): void;
+//     complete(): void;
+// }
 
-  // type Subscriber<T> = (observer: SubscriptionObserver<T>) => void | (() => void) | Subscription;
+// type Subscriber<T> = (observer: SubscriptionObserver<T>) => void | (() => void) | Subscription;
 
-  // interface ObservableLike<T> {
-  //     subscribe?: Subscriber<T>;
-  //     [Symbol.observable](): Observable<T> | ObservableLike<T>;
-  // }
+// interface ObservableLike<T> {
+//     subscribe?: Subscriber<T>;
+//     [Symbol.observable](): Observable<T> | ObservableLike<T>;
+// }
 
-  // interface Subscription {
-  //     closed: boolean;
-  //     unsubscribe(): void;
-  // }
-  type subscription = {
-    closed: bool,
-    unsubscribe: unit => unit,
+module Subscription = {
+  module Js_ = {
+    // interface Subscription {
+    //     closed: boolean;
+    //     unsubscribe(): void;
+    // }
+    type t = {
+      closed: bool,
+      unsubscribe: unit => unit,
+    };
+  };
+  type t = Js_.t;
+};
+
+module Observer = {
+  module Js_ = {
+    // interface Observer<T> {
+    //     start?(subscription: Subscription): any;
+    //     next?(value: T): void;
+    //     error?(errorValue: any): void;
+    //     complete?(): void;
+    // }
+    type t('t) = {
+      start: option(Subscription.Js_.t => unit),
+      next: option('t => unit),
+      error: option(Js.Json.t => unit),
+      complete: option(unit => unit),
+    };
   };
 
-  // interface Observer<T> {
-  //     start?(subscription: Subscription): any;
-  //     next?(value: T): void;
-  //     error?(errorValue: any): void;
-  //     complete?(): void;
-  // }
-  type observer('t) = {
-    start: option(subscription => unit),
+  type t('t) = {
+    start: option(Subscription.t => unit),
     next: option('t => unit),
     error: option(Js.Json.t => unit),
     complete: option(unit => unit),
@@ -37,41 +51,49 @@ module ZenObservable = {
 };
 
 module Observable = {
-  // declare class Observable<T> {
-  //     constructor(subscriber: ZenObservable.Subscriber<T>)
+  module Js_ = {
+    // declare class Observable<T> {
+    //     constructor(subscriber: ZenObservable.Subscriber<T>)
 
-  //     subscribe(observer: ZenObservable.Observer<T>): ZenObservable.Subscription;
-  //     subscribe(onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
+    //     subscribe(observer: ZenObservable.Observer<T>): ZenObservable.Subscription;
+    //     subscribe(onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
 
-  //     [Symbol.observable](): Observable<T>;
+    //     [Symbol.observable](): Observable<T>;
 
-  //     forEach(callback: (value: T) => void): Promise<void>;
-  //     map<R>(callback: (value: T) => R): Observable<R>;
-  //     filter(callback: (value: T) => boolean): Observable<T>;
-  //     reduce(callback: (previousValue: T, currentValue: T) => T, initialValue?: T): Observable<T>;
-  //     reduce<R>(callback: (previousValue: R, currentValue: T) => R, initialValue?: R): Observable<R>;
-  //     flatMap<R>(callback: (value: T) => ZenObservable.ObservableLike<R>): Observable<R>;
-  //     concat<R>(...observable: Array<Observable<R>>): Observable<R>;
+    //     forEach(callback: (value: T) => void): Promise<void>;
+    //     map<R>(callback: (value: T) => R): Observable<R>;
+    //     filter(callback: (value: T) => boolean): Observable<T>;
+    //     reduce(callback: (previousValue: T, currentValue: T) => T, initialValue?: T): Observable<T>;
+    //     reduce<R>(callback: (previousValue: R, currentValue: T) => R, initialValue?: R): Observable<R>;
+    //     flatMap<R>(callback: (value: T) => ZenObservable.ObservableLike<R>): Observable<R>;
+    //     concat<R>(...observable: Array<Observable<R>>): Observable<R>;
 
-  //     static from<R>(observable: Observable<R> | ZenObservable.ObservableLike<R> | ArrayLike<R>): Observable<R>;
-  //     static of<R>(...items: R[]): Observable<R>;
-  // }
-  type t('t);
+    //     static from<R>(observable: Observable<R> | ZenObservable.ObservableLike<R> | ArrayLike<R>): Observable<R>;
+    //     static of<R>(...items: R[]): Observable<R>;
+    // }
+    type t('t);
 
-  [@bs.send]
-  external subscribe:
-    (
-      t('t),
-      ~onNext: 't => unit,
-      ~onError: Js.Json.t => unit=?,
-      ~onComplete: unit => unit=?,
-      unit
-    ) =>
-    ZenObservable.subscription =
-    "subscribe";
+    // <R>(callback: (value: T) => R): Observable<R>;
+    [@bs.send] external map: (t('t), 't => 'r) => t('r) = "map";
 
-  [@bs.send]
-  external subscribeWithObserver:
-    (t('t), ZenObservable.observer('t)) => ZenObservable.subscription =
-    "subscribe";
+    // (onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
+    [@bs.send]
+    external subscribe:
+      (
+        t('t),
+        ~onNext: 't => unit,
+        ~onError: Js.Json.t => unit=?,
+        ~onComplete: unit => unit=?,
+        unit
+      ) =>
+      Subscription.t =
+      "subscribe";
+
+    // (observer: ZenObservable.Observer<T>): ZenObservable.Subscription;
+    [@bs.send]
+    external subscribeWithObserver: (t('t), Observer.t('t)) => Subscription.t =
+      "subscribe";
+  };
+
+  include Js_;
 };


### PR DESCRIPTION
This adds support for the `watchQuery` method on `ApolloClient`. The bindings here were a little awkward made more difficult by a bug in Apollo Client 3 where you can't `.map` an `ObservableQuery`. I'm sure we can do better on another pass.