### PR TITLE
QueryResult methods

### DIFF
--- a/EXAMPLES/src/App.re
+++ b/EXAMPLES/src/App.re
@@ -1,7 +1,7 @@
 [@react.component]
 let make = () => {
   <ApolloClient.React.ApolloProvider client=Client.instance>
-    <h2> "Hooks Usage"->React.string </h2>
+    <h2> "Fetching Data with Hooks"->React.string </h2>
     <h4> "Simple Query"->React.string </h4>
     <Query_OverlySimple />
     <h4> "Typical Query"->React.string </h4>
@@ -10,9 +10,13 @@ let make = () => {
     <Query_Lazy />
     <h4> "Mutation"->React.string </h4>
     <Mutation />
-    <h2> "Client Usage"->React.string </h2>
+    <h4> "Subcription"->React.string </h4>
+    <Subscription />
+    <h4> "Query with Subscription for More"->React.string </h4>
+    <Query_SubscribeToMore />
+    <h2> "Fetching Data Directly with the Client"->React.string </h2>
     <ClientBasics />
-    <h2> "Fragments Usage"->React.string </h2>
+    <h2> "Fragments"->React.string </h2>
     <Query_Fragments />
   </ApolloClient.React.ApolloProvider>;
 };

--- a/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
+++ b/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
@@ -1,0 +1,77 @@
+module TodosQuery = [%graphql
+  {|
+    query TodosQuery {
+      todos: allTodos {
+        id
+        completed
+        text
+      }
+    }
+  |}
+];
+
+module SorryItsNotASubscriptionForTodos = [%graphql
+  {|
+    subscription SorryItsNotASubscriptionForTodos {
+      siteStatisticsUpdated {
+        currentVisitorsOnline
+      }
+    }
+  |}
+];
+
+[@react.component]
+let make = () => {
+  let queryResult = TodosQuery.use();
+
+  /**
+   * Sorry, this example is nonsensical given the current schema, but I'm gonna proceed anyway
+   */
+  React.useEffect0(() => {
+    queryResult->ApolloClient.QueryResult.subscribeToMore(
+      ~subscription=(module SorryItsNotASubscriptionForTodos),
+      ~updateQuery=
+        (previous, {subscriptionData: {data: {siteStatisticsUpdated}}}) => {
+          let count =
+            siteStatisticsUpdated
+            ->Belt.Option.map(stats => stats.currentVisitorsOnline)
+            ->Belt.Option.getWithDefault(0)
+            ->string_of_int;
+
+          {
+            todos:
+              Belt.Array.concat(
+                previous.todos,
+                [|
+                  {
+                    __typename: "TodoItem",
+                    id: "subscribeToMoreTodo",
+                    completed: None,
+                    text: "Hello, " ++ count ++ " vistors online",
+                  },
+                |],
+              ),
+          };
+        },
+      (),
+    );
+    None;
+  });
+
+  <>
+    <p>
+      "[ Not functional, but the examples are still valid ]"->React.string
+    </p>
+    {switch (queryResult) {
+     | {data: Some({todos})} =>
+       <p>
+         {React.string(
+            "There are "
+            ++ todos->Belt.Array.length->string_of_int
+            ++ " To-Dos",
+          )}
+       </p>
+     | _ignoredForExample => React.null
+     }}
+  </>;
+};

--- a/EXAMPLES/src/hooksUsage/Query_Typical.re
+++ b/EXAMPLES/src/hooksUsage/Query_Typical.re
@@ -17,7 +17,7 @@ let make = () => {
   <div>
     {switch (queryResult) {
      | {loading: true, data: None} => <p> "Loading"->React.string </p>
-     | {loading, data: Some({todos}), error, fetchMore} =>
+     | {loading, data: Some({todos}), error} =>
        <>
          <dialog>
            {loading ? <p> "Refreshing..."->React.string </p> : React.null}
@@ -39,19 +39,20 @@ let make = () => {
          <p>
            <button
              onClick={_ =>
-               fetchMore(
-                 ~updateQuery=
-                   (previousData, {fetchMoreResult}) => {
-                     switch (fetchMoreResult) {
-                     | Some({todos: newTodos}) => {
-                         todos:
-                           Belt.Array.concat(previousData.todos, newTodos),
+               queryResult
+               ->ApolloClient.QueryResult.fetchMore(
+                   ~updateQuery=
+                     (previousData, {fetchMoreResult}) => {
+                       switch (fetchMoreResult) {
+                       | Some({todos: newTodos}) => {
+                           todos:
+                             Belt.Array.concat(previousData.todos, newTodos),
+                         }
+                       | None => previousData
                        }
-                     | None => previousData
-                     }
-                   },
-                 (),
-               )
+                     },
+                   (),
+                 )
                ->ignore
              }>
              "Fetch More!"->React.string

--- a/EXAMPLES/src/hooksUsage/Subscription.re
+++ b/EXAMPLES/src/hooksUsage/Subscription.re
@@ -1,0 +1,29 @@
+module SorryItsNotASubscriptionForTodos = [%graphql
+  {|
+    subscription SorryItsNotASubscriptionForTodos {
+      siteStatisticsUpdated {
+        currentVisitorsOnline
+      }
+    }
+  |}
+];
+
+[@react.component]
+let make = () => {
+  <>
+    <p>
+      "[ Not functional, but the examples are still valid ]"->React.string
+    </p>
+    {switch (SorryItsNotASubscriptionForTodos.use()) {
+     | {data: Some({siteStatisticsUpdated: Some({currentVisitorsOnline})})} =>
+       <p>
+         {React.string(
+            "There are "
+            ++ string_of_int(currentVisitorsOnline)
+            ++ " visitors online",
+          )}
+       </p>
+     | _ignoredForExample => React.null
+     }}
+  </>;
+};

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
@@ -149,6 +149,126 @@ module WatchQueryOptions = {
     };
 };
 
+module UpdateQueryFn = {
+  module Js_ = {
+    type t_options_subscriptionData('jsSubscriptionData) = {
+      data: 'jsSubscriptionData,
+    };
+    type t_options('jsSubscriptionData, 'variables) = {
+      subscriptionData: t_options_subscriptionData('jsSubscriptionData),
+    };
+    // export declare type UpdateQueryFn<TData = any, TSubscriptionVariables = OperationVariables, TSubscriptionData = TData> = (previousQueryResult: TData, options: {
+    //     subscriptionData: {
+    //         data: TSubscriptionData;
+    //     };
+    //     variables?: TSubscriptionVariables;
+    // }) => TData;
+    type t('jsQueryData, 'subscriptionVariables, 'jsSubscriptionData) =
+      (
+        . 'jsQueryData,
+        t_options('jsSubscriptionData, 'subscriptionVariables)
+      ) =>
+      'jsQueryData;
+  };
+  type t_options_subscriptionData('jsSubscriptionData) = {
+    data: 'jsSubscriptionData,
+  };
+  type t_options('jsSubscriptionData, 'variables) = {
+    subscriptionData: t_options_subscriptionData('jsSubscriptionData),
+  };
+
+  type t('queryData, 'subscriptionVariables, 'subscriptionData) =
+    ('queryData, t_options('subscriptionData, 'subscriptionVariables)) =>
+    'queryData;
+
+  let toJs:
+    (
+      t('queryData, 'subscriptionVariables, 'subscriptionData),
+      ~queryParse: 'jsQueryData => 'queryData,
+      ~querySerialize: 'queryData => 'jsQueryData,
+      ~subscriptionParse: 'jsSubscriptionData => 'subscriptionData
+    ) =>
+    Js_.t('jsQueryData, 'subscriptionVariables, 'jsSubscriptionData) =
+    (t, ~queryParse, ~querySerialize, ~subscriptionParse) =>
+      (. jsQueryData, {subscriptionData: {data}}) =>
+        t(
+          jsQueryData->queryParse,
+          {
+            subscriptionData: {
+              data: data->subscriptionParse,
+            },
+          },
+        )
+        ->querySerialize;
+};
+
+module SubscribeToMoreOptions = {
+  module Js_ = {
+    // export declare type SubscribeToMoreOptions<TData = any, TSubscriptionVariables = OperationVariables, TSubscriptionData = TData> = {
+    //     document: DocumentNode;
+    //     variables?: TSubscriptionVariables;
+    //     updateQuery?: UpdateQueryFn<TData, TSubscriptionVariables, TSubscriptionData>;
+    //     onError?: (error: Error) => void;
+    //     context?: Record<string, any>;
+    // };
+
+    type t('jsQueryData, 'subscriptionVariables, 'jsSubscriptionData) = {
+      document: Graphql.documentNode,
+      // We don't allow optional variables because it's not typesafe
+      variables: 'subscriptionVariables,
+      updateQuery:
+        option(
+          UpdateQueryFn.Js_.t(
+            'jsQueryData,
+            'subscriptionVariables,
+            'jsSubscriptionData,
+          ),
+        ),
+      onError: option(Js.Exn.t => unit),
+      context: option(Js.Json.t),
+    };
+  };
+
+  type t('queryData, 'subscriptionVariables, 'subscriptionData) = {
+    document: Graphql.documentNode,
+    variables: 'subscriptionVariables,
+    updateQuery:
+      option(
+        UpdateQueryFn.t(
+          'queryData,
+          'subscriptionVariables,
+          'subscriptionData,
+        ),
+      ),
+    onError: option(Js.Exn.t => unit),
+    context: option(Js.Json.t),
+  };
+
+  let toJs:
+    (
+      t('queryData, 'subscriptionVariables, 'subscriptionData),
+      ~queryParse: 'jsQueryData => 'queryData,
+      ~querySerialize: 'queryData => 'jsQueryData,
+      ~subscriptionParse: 'jsSubscriptionData => 'subscriptionData
+    ) =>
+    Js_.t('jsQueryData, 'subscriptionVariables, 'jsSubscriptionData) =
+    (t, ~queryParse, ~querySerialize, ~subscriptionParse) => {
+      document: t.document,
+      variables: t.variables,
+      updateQuery:
+        t.updateQuery
+        ->Belt.Option.map(
+            UpdateQueryFn.toJs(
+              ~queryParse,
+              ~querySerialize,
+              ~subscriptionParse,
+            ),
+          ),
+      onError: t.onError,
+      context: t.context,
+    };
+};
+
 module MutationUpdaterFn = {
   module Js_ = {
     type t('jsData) =

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
@@ -25,10 +25,12 @@ module Js_ = {
 };
 
 let useLazyQuery:
-  type data jsVariables.
+  type data jsData jsVariables.
     (
       ~query: (module Operation with
-                 type t = data and type Raw.t_variables = jsVariables),
+                 type t = data and
+                 type Raw.t = jsData and
+                 type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -42,7 +44,7 @@ let useLazyQuery:
       ~ssr: bool=?,
       unit
     ) =>
-    QueryTuple.t(data, jsVariables) =
+    QueryTuple.t(data, jsData, jsVariables) =
   (
     ~query as (module Operation),
     ~client=?,
@@ -93,10 +95,12 @@ let useLazyQuery:
   };
 
 let useLazyQueryWithVariables:
-  type data jsVariables.
+  type data jsData jsVariables.
     (
       ~query: (module Operation with
-                 type t = data and type Raw.t_variables = jsVariables),
+                 type t = data and
+                 type Raw.t = jsData and
+                 type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -110,7 +114,7 @@ let useLazyQueryWithVariables:
       ~ssr: bool=?,
       jsVariables
     ) =>
-    QueryTuple__noVariables.t(data, jsVariables) =
+    QueryTuple__noVariables.t(data, jsData, jsVariables) =
   (
     ~query as (module Operation),
     ~client=?,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -22,10 +22,12 @@ module Js_ = {
 };
 
 let useQuery:
-  type data jsVariables.
+  type data jsData jsVariables.
     (
       ~query: (module Operation with
-                 type t = data and type Raw.t_variables = jsVariables),
+                 type t = data and
+                 type Raw.t = jsData and
+                 type Raw.t_variables = jsVariables),
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?,
       ~displayName: string=?,
@@ -40,7 +42,7 @@ let useQuery:
       ~ssr: bool=?,
       jsVariables
     ) =>
-    QueryResult.t(data, jsVariables) =
+    QueryResult.t(data, jsData, jsVariables) =
   (
     ~query as (module Operation),
     ~client=?,

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -9,8 +9,12 @@ module Graphql = ApolloClient__Graphql;
 module MutationUpdaterFn = ApolloClient__Core_WatchQueryOptions.MutationUpdaterFn;
 module NetworkStatus = ApolloClient__Core_NetworkStatus;
 module RefetchQueryDescription = ApolloClient__Core_WatchQueryOptions.RefetchQueryDescription;
+module SubscribeToMoreOptions = ApolloClient__Core_WatchQueryOptions.SubscribeToMoreOptions;
 module Types = ApolloClient__Types;
+module UpdateQueryFn = ApolloClient__Core_WatchQueryOptions.UpdateQueryFn;
 module WatchQueryFetchPolicy = ApolloClient__Core_WatchQueryOptions.WatchQueryFetchPolicy;
+
+module type Operation = Types.Operation;
 
 module QueryHookOptions = {
   module Js_ = {
@@ -193,6 +197,8 @@ module QueryLazyOptions = {
 };
 
 module QueryResult = {
+  type useMethodFunctionsInThisModuleInstead;
+
   module Js_ = {
     type t_fetchMoreOptions_updateQueryOptions('jsData, 'variables) = {
       fetchMoreResult: option('jsData),
@@ -219,6 +225,8 @@ module QueryResult = {
         'jsData,
     };
 
+    type t_updateQueryOptions('variables) = {variables: 'variables};
+
     // export interface QueryResult<TData = any, TVariables = OperationVariables> extends ObservableQueryFields<TData, TVariables> {
     //     client: ApolloClient<any>;
     //     data: TData | undefined;
@@ -234,12 +242,63 @@ module QueryResult = {
       error: option(ApolloError.Js_.t),
       loading: bool,
       networkStatus: NetworkStatus.t,
-      // ...extends ObservableQueryFields
-      fetchMore:
-        t_fetchMoreOptions('jsData, 'variables) =>
-        Js.Promise.t(ApolloQueryResult.Js_.t('jsData)),
+      // ...extends ObservableQueryFields<TData, TVariables> = Pick<ObservableQuery<TData, TVariables>, 'startPolling' | 'stopPolling' | 'subscribeToMore' | 'updateQuery' | 'refetch' | 'variables'>
+      fetchMore: useMethodFunctionsInThisModuleInstead,
+      refetch: useMethodFunctionsInThisModuleInstead,
+      startPolling: useMethodFunctionsInThisModuleInstead,
+      stopPolling: useMethodFunctionsInThisModuleInstead,
+      subscribeToMore: useMethodFunctionsInThisModuleInstead,
+      updateQuery: useMethodFunctionsInThisModuleInstead,
+      variables: 'variables,
     };
+
+    [@bs.send]
+    external fetchMore:
+      (t('jsData, 'variables), t_fetchMoreOptions('jsData, 'variables)) =>
+      Js.Promise.t(ApolloQueryResult.Js_.t('jsData)) =
+      "fetchMore";
+
+    [@bs.send]
+    external refetch:
+      (t('jsData, 'variables), 'variables) =>
+      Js.Promise.t(ApolloQueryResult.Js_.t('jsData)) =
+      "refetch";
+
+    [@bs.send]
+    external startPolling: (t('jsData, 'variables), int) => unit =
+      "startPolling";
+
+    [@bs.send]
+    external stopPolling: (t('jsData, 'variables), unit) => unit =
+      "stopPolling";
+
+    [@bs.send]
+    external updateQuery:
+      (
+        t('jsData, 'variables),
+        ('jsData, t_updateQueryOptions('variables)) => 'jsData
+      ) =>
+      unit =
+      "updateQuery";
+
+    // subscribeToMore<TSubscriptionData = TData, TSubscriptionVariables = TVariables>(options: SubscribeToMoreOptions<TData, TSubscriptionVariables, TSubscriptionData>): () => void;
+    [@bs.send]
+    external subscribeToMore:
+      (
+        t('jsData, 'variables),
+        SubscribeToMoreOptions.Js_.t(
+          'jsData,
+          'subscriptionVariables,
+          'jsSubscriptionData,
+        )
+      ) =>
+      unit =
+      "subscribeToMore";
   };
+
+  type t_updateQueryOptions('variables) =
+    Js_.t_updateQueryOptions('variables);
+
   type t_fetchMoreOptions_updateQueryOptions('data, 'variables) = {
     fetchMoreResult: option('data),
     variables: option('variables),
@@ -258,48 +317,74 @@ module QueryResult = {
       ),
   };
 
-  type t('data, 'variables) = {
+  type t('data, 'jsData, 'variables) = {
     called: bool,
     client: ApolloClient.t,
     data: option('data),
     error: option(ApolloError.t),
-    fetchMore:
-      (
-        ~context: Js.Json.t=?,
-        ~variables: 'variables=?,
-        ~updateQuery: (
-                        'data,
-                        t_fetchMoreOptions_updateQueryOptions(
-                          'data,
-                          'variables,
-                        )
-                      ) =>
-                      'data
-                        =?,
-        unit
-      ) =>
-      Js.Promise.t(ApolloQueryResult.t('data)),
     loading: bool,
     networkStatus: NetworkStatus.t,
+    fetchMore: useMethodFunctionsInThisModuleInstead,
+    refetch: useMethodFunctionsInThisModuleInstead,
+    startPolling: useMethodFunctionsInThisModuleInstead,
+    stopPolling: useMethodFunctionsInThisModuleInstead,
+    subscribeToMore: useMethodFunctionsInThisModuleInstead,
+    updateQuery: useMethodFunctionsInThisModuleInstead,
+    __parse: 'jsData => 'data,
+    __serialize: 'data => 'jsData,
   };
+
+  external unsafeCastForMethod:
+    t('data, 'jsData, 'variables) => Js_.t('jsData, 'variables) =
+    "%identity";
 
   let fromJs:
     (
       Js_.t('jsData, 'variables),
-      ~parse: 'jsData => 'parsedData,
-      ~serialize: 'parsedData => 'jsData
+      ~parse: 'jsData => 'data,
+      ~serialize: 'data => 'jsData
     ) =>
-    t('parsedData, 'variables) =
+    t('data, 'jsData, 'variables) =
     (js, ~parse, ~serialize) => {
       called: js.called,
       client: js.client,
       data: js.data->Belt.Option.map(parse),
       error: js.error->Belt.Option.map(ApolloError.fromJs),
-      fetchMore: (~context=?, ~variables=?, ~updateQuery=?, ()) => {
-        js.fetchMore(
+      loading: js.loading,
+      networkStatus: js.networkStatus,
+      fetchMore: js.fetchMore,
+      refetch: js.refetch,
+      startPolling: js.startPolling,
+      stopPolling: js.stopPolling,
+      subscribeToMore: js.subscribeToMore,
+      updateQuery: js.updateQuery,
+      __parse: parse,
+      __serialize: serialize,
+    };
+
+  let fetchMore:
+    (
+      t('queryData, 'jsQueryData, 'variables),
+      ~context: Js.Json.t=?,
+      ~variables: 'variables=?,
+      ~updateQuery: (
+                      'data,
+                      t_fetchMoreOptions_updateQueryOptions('data, 'variables)
+                    ) =>
+                    'data
+                      =?,
+      unit
+    ) =>
+    Js.Promise.t(ApolloQueryResult.t('data)) =
+    (queryResult, ~context=?, ~variables=?, ~updateQuery=?, ()) => {
+      let serialize = queryResult.__serialize;
+      let parse = queryResult.__parse;
+
+      queryResult
+      ->unsafeCastForMethod
+      ->Js_.fetchMore(
           Js_.t_fetchMoreOptions(
             ~context?,
-            // ~query,
             ~updateQuery=?
               updateQuery->Belt.Option.map(updateQuery =>
                 (.
@@ -325,14 +410,96 @@ module QueryResult = {
             (),
           ),
         )
-        ->Js.Promise.then_(
-            jsResult =>
-              Js.Promise.resolve(ApolloQueryResult.fromJs(jsResult, ~parse)),
-            _,
-          );
-      },
-      loading: js.loading,
-      networkStatus: js.networkStatus,
+      ->Js.Promise.then_(
+          jsResult =>
+            Js.Promise.resolve(ApolloQueryResult.fromJs(jsResult, ~parse)),
+          _,
+        );
+    };
+
+  let refetch:
+    (t('data, 'jsData, 'variables), 'variables) =>
+    Js.Promise.t(ApolloQueryResult.t('data)) =
+    (queryResult, variables) =>
+      queryResult
+      ->unsafeCastForMethod
+      ->Js_.refetch(variables)
+      ->Js.Promise.then_(
+          jsApolloQueryResult =>
+            Js.Promise.resolve(
+              jsApolloQueryResult->ApolloQueryResult.fromJs(
+                ~parse=queryResult.__parse,
+              ),
+            ),
+          _,
+        );
+
+  [@bs.send]
+  external startPolling: (t('data, 'jsData, 'variables), int) => unit =
+    "startPolling";
+
+  [@bs.send]
+  external stopPolling: (t('data, 'jsData, 'variables), unit) => unit =
+    "stopPolling";
+
+  let subscribeToMore:
+    type subscriptionData subscriptionVariables.
+      (
+        t('queryData, 'jsQueryData, 'variables),
+        ~subscription: (module Operation with
+                          type t = subscriptionData and
+                          type Raw.t_variables = subscriptionVariables),
+        ~updateQuery: UpdateQueryFn.t(
+                        'queryData,
+                        subscriptionVariables,
+                        subscriptionData,
+                      )
+                        =?,
+        ~onError: Js.Exn.t => unit=?,
+        ~context: Js.Json.t=?,
+        subscriptionVariables
+      ) =>
+      unit =
+    (
+      queryResult,
+      ~subscription as (module Operation),
+      ~updateQuery=?,
+      ~onError=?,
+      ~context=?,
+      variables,
+    ) => {
+      queryResult
+      ->unsafeCastForMethod
+      ->Js_.subscribeToMore(
+          SubscribeToMoreOptions.toJs(
+            {
+              document: Operation.query,
+              variables,
+              updateQuery,
+              onError,
+              context,
+            },
+            ~queryParse=queryResult.__parse,
+            ~querySerialize=queryResult.__serialize,
+            ~subscriptionParse=Operation.parse,
+          ),
+        );
+    };
+
+  let updateQuery:
+    (
+      t('data, 'jsData, 'variables),
+      ('data, t_updateQueryOptions('variables)) => 'data
+    ) =>
+    unit =
+    (queryResult, updateQueryFn) => {
+      let parse = queryResult.__parse;
+      let serialize = queryResult.__serialize;
+      queryResult
+      ->unsafeCastForMethod
+      ->Js_.updateQuery((jsPreviousData, options) => {
+          updateQueryFn(jsPreviousData->parse, options)->serialize
+        });
     };
 };
 
@@ -396,8 +563,8 @@ module LazyQueryResult = {
     type t('jsData, 'variables) = Union.t;
   };
 
-  type t('data, 'variables) =
-    | Executed(QueryResult.t('data, 'variables))
+  type t('data, 'jsData, 'variables) =
+    | Executed(QueryResult.t('data, 'jsData, 'variables))
     | Unexecuted(UnexecutedLazyResult.t);
 
   let fromJs:
@@ -406,7 +573,7 @@ module LazyQueryResult = {
       ~parse: 'jsData => 'data,
       ~serialize: 'data => 'jsData
     ) =>
-    t('data, 'variables) =
+    t('data, 'jsData, 'variables) =
     (js, ~parse, ~serialize) => {
       switch (js->Js_.Union.classify) {
       | UnexecutedLazyResult(v) => Unexecuted(v->UnexecutedLazyResult.fromJs)
@@ -424,9 +591,9 @@ module QueryTuple = {
     );
   };
 
-  type t('data, 'variables) = (
+  type t('data, 'jsData, 'variables) = (
     (~context: Js.Json.t=?, 'variables) => unit,
-    LazyQueryResult.t('data, 'variables),
+    LazyQueryResult.t('data, 'jsData, 'variables),
   );
 
   let fromJs:
@@ -435,7 +602,7 @@ module QueryTuple = {
       ~parse: 'jsData => 'data,
       ~serialize: 'data => 'jsData
     ) =>
-    t('data, 'variables) =
+    t('data, 'jsData, 'variables) =
     ((jsExecuteQuery, jsLazyQueryResult), ~parse, ~serialize) => (
       (~context=?, variables) => jsExecuteQuery({context, variables}),
       jsLazyQueryResult->LazyQueryResult.fromJs(~parse, ~serialize),
@@ -447,9 +614,9 @@ module QueryTuple__noVariables = {
     type t('jsData, 'variables) = QueryTuple.Js_.t('jsData, 'variables);
   };
 
-  type t('data, 'variables) = (
+  type t('data, 'jsData, 'variables) = (
     (~context: Js.Json.t=?, unit) => unit,
-    LazyQueryResult.t('data, 'variables),
+    LazyQueryResult.t('data, 'jsData, 'variables),
   );
 
   let fromJs:
@@ -459,7 +626,7 @@ module QueryTuple__noVariables = {
       ~serialize: 'data => 'jsData,
       ~variables: 'variables
     ) =>
-    t('data, 'variables) =
+    t('data, 'jsData, 'variables) =
     ((jsExecuteQuery, jsLazyQueryResult), ~parse, ~serialize, ~variables) => (
       (~context=?, ()) => jsExecuteQuery({context, variables}),
       jsLazyQueryResult->LazyQueryResult.fromJs(~parse, ~serialize),

--- a/src/Jeddeloh__ApolloClient.re
+++ b/src/Jeddeloh__ApolloClient.re
@@ -56,8 +56,6 @@ module React = {
 
 module Utilities = ApolloClient__Utilities;
 
-module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
-
 module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions;
 module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions;
 module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions;
@@ -71,3 +69,9 @@ let readQuery = ApolloClient__ApolloClient.readQuery;
 let watchQuery = ApolloClient__ApolloClient.watchQuery;
 let writeFragment = ApolloClient__ApolloClient.writeFragment;
 let writeQuery = ApolloClient__ApolloClient.writeQuery;
+
+/**
+ * Modules below are exposed for convenient access
+ */
+module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
+module QueryResult = ApolloClient__React_Types.QueryResult;


### PR DESCRIPTION
Here I was, thinking I was done, and I'd missed this huge swath of extended properties on QueryResult 😆.

This PR basically adds stuff like `fetchMore` and `subscribeToMore`. It's a bit tragic for a number of reasons:
- I have to mix and match direct access on the record for values, but have separate functions for methods on the same result object which can sometimes be a little confusing when things feel _so_ close to the javascript usage.
- Separating the methods from the result record means that I lose context of the operation that was used originally so now I  attach `parse` and `serialize` to the result record to be used in the method functions.

On the upside, I've attached them as abstract types and you'll get the following error when trying to use them:
```
  This expression has type
    ApolloClient__React_Types.QueryResult.useMethodFunctionsInThisModuleInstead
  It is not a function.
```
Not the best, but maybe better than being missing completely.