### PR TITLE
Improved root module structure and easier types access

### DIFF
--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -26,7 +26,7 @@
     "graphql": "^14.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "reason-apollo-client": "0.0.1-beta.1",
+    "reason-apollo-client": "^0.0.1-beta.1",
     "reason-promise": "1.1.1",
     "reason-react": "0.9.1",
     "subscriptions-transport-ws": "0.9.16"

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -1,3 +1,5 @@
+module ApolloQueryResult = ApolloClient.Types.ApolloQueryResult;
+module ObservableQuery = ApolloClient.Types.ObservableQuery;
 module Prometo = Yawaramin__Prometo;
 
 module AddTodoMutation = [%graphql
@@ -58,7 +60,7 @@ let logTodos_bad_jsPromise = _ =>
   Client.instance
   ->ApolloClient.query(~query=(module TodosQuery), ())
   ->Js.Promise.then_(
-      (result: ApolloClient__ApolloClient.ApolloQueryResult.t(_)) =>
+      (result: ApolloQueryResult.t(_)) =>
         switch (result) {
         | {data: Some({TodosQuery.todos})} =>
           Js.Promise.resolve(Js.log2("query To-Dos: ", todos))
@@ -89,7 +91,7 @@ let addTodo = _ =>
 let watchQuerySubscription =
   Client.instance
   ->ApolloClient.watchQuery(~query=(module TodosQuery), ())
-  ->ApolloClient.ObservableQuery.subscribe(
+  ->ObservableQuery.subscribe(
       ~onNext=
         result =>
           switch (result) {

--- a/EXAMPLES/src/hooksUsage/Mutation.re
+++ b/EXAMPLES/src/hooksUsage/Mutation.re
@@ -1,3 +1,5 @@
+module Cache = ApolloClient.Cache;
+
 module AddTodoMutation = [%graphql
   {|
     mutation AddTodo($text: String!) {
@@ -57,7 +59,7 @@ let make = () => {
                    */
                   Js.log2("mutate.update To-Do: ", todo);
                   let _unusedRef =
-                    cache->ApolloClient__Cache_Core_Cache.ApolloCache.writeFragment(
+                    cache->Cache.writeFragment(
                       ~fragment=(module Fragments.TodoItem),
                       ~data={
                         __typename: todo.__typename,
@@ -68,7 +70,7 @@ let make = () => {
                       (),
                     );
                   let _unusedRef =
-                    cache->ApolloClient__Cache_Core_Cache.ApolloCache.writeQuery(
+                    cache->Cache.writeQuery(
                       ~query=(module TodosQuery),
                       ~data={
                         todos: [|

--- a/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
+++ b/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
@@ -1,3 +1,5 @@
+module QueryResult = ApolloClient.Types.QueryResult;
+
 module TodosQuery = [%graphql
   {|
     query TodosQuery {
@@ -28,7 +30,7 @@ let make = () => {
    * Sorry, this example is nonsensical given the current schema, but I'm gonna proceed anyway
    */
   React.useEffect0(() => {
-    queryResult->ApolloClient.QueryResult.subscribeToMore(
+    queryResult->QueryResult.subscribeToMore(
       ~subscription=(module SorryItsNotASubscriptionForTodos),
       ~updateQuery=
         (previous, {subscriptionData: {data: {siteStatisticsUpdated}}}) => {

--- a/EXAMPLES/src/hooksUsage/Query_Typical.re
+++ b/EXAMPLES/src/hooksUsage/Query_Typical.re
@@ -1,3 +1,5 @@
+module QueryResult = ApolloClient.Types.QueryResult;
+
 module TodosQuery = [%graphql
   {|
     query TodosQuery {
@@ -40,7 +42,7 @@ let make = () => {
            <button
              onClick={_ =>
                queryResult
-               ->ApolloClient.QueryResult.fetchMore(
+               ->QueryResult.fetchMore(
                    ~updateQuery=
                      (previousData, {fetchMoreResult}) => {
                        switch (fetchMoreResult) {

--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ let make = () => {
 
 Other than some slightly different ergonomics, the underlying functionality is almost identical to the [official Apollo Client 3 docs](https://www.apollographql.com/docs/react/v3.0-beta/get-started/), so that is still a good resource for working with this library.
 
+It's probably worth noting this library leverages records heavily which allows for very similar syntax to working with javascript objects and other benefits, but comes with a couple drawbacks.
+
+- You may need to annotate the types if you're using a record outside of the exact place it is used, so we expose every type from the `ApolloClient.Types` module for convenience
+- Bindings to methods on javascript objects work a little differently. You have to use the method function in the module for that type.
+
+Example:
+
+```reason
+  /** Inspecting the types reveals this is a QueryResult.t */
+  let queryResult = SomeQuery.use();
+
+  /** I can destructure, pattern match, or access properties that are values like normal */
+  switch (queryResult) {
+    | {loading: true} =>
+    /** do something */
+  }
+
+  /** But if I want to use a method on the javascript object,
+      I need to use a function defined in the module for that type */
+  queryResult->ApolloClient.Types.QueryResult.fetchMore;
+  /** ☝️Note that you don't have to go searching for the type.
+      The intent is to have everything accessible under Types */
+```
+
 ## Recommended Editor Extensions (Visual Studio Code)
 
 [vscode-reasonml-graphql](https://marketplace.visualstudio.com/items?itemName=GabrielNordeborn.vscode-reasonml-graphql) provides syntax highlighting, autocompletion, formatting and more for your graphql operations

--- a/src/ReasonMLCommunity__ApolloClient.re
+++ b/src/ReasonMLCommunity__ApolloClient.re
@@ -1,34 +1,44 @@
-module Errors = {
-  module ApolloError = ApolloClient__Errors_ApolloError;
-  module GraphqlError = ApolloClient__Graphql_Error_GraphQLError;
+// Creating a client
+module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions;
+module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions;
+module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions;
+module DefaultOptions = ApolloClient__ApolloClient.DefaultOptions;
+
+type t = ApolloClient__ApolloClient.t;
+let make = ApolloClient__ApolloClient.make;
+
+// Fetching data
+let mutate = ApolloClient__ApolloClient.mutate;
+let query = ApolloClient__ApolloClient.query;
+let readQuery = ApolloClient__ApolloClient.readQuery;
+let watchQuery = ApolloClient__ApolloClient.watchQuery;
+let writeFragment = ApolloClient__ApolloClient.writeFragment;
+let writeQuery = ApolloClient__ApolloClient.writeQuery;
+
+module React = {
+  module ApolloProvider = ApolloClient__React_Context_ApolloProvider;
+  let useApolloClient = ApolloClient__React_Hooks_UseApolloClient.useApolloClient;
+  let useMutation = ApolloClient__React_Hooks_UseMutation.useMutation;
+  let useMutationWithVariables = ApolloClient__React_Hooks_UseMutation.useMutationWithVariables;
+  let useLazyQuery = ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery;
+  let useLazyQueryWithVariables = ApolloClient__React_Hooks_UseLazyQuery.useLazyQueryWithVariables;
+  let useQuery = ApolloClient__React_Hooks_UseQuery.useQuery;
+  let useSubscription = ApolloClient__React_Hooks_UseSubscription.useSubscription;
 };
 
-module Bindings = {
-  module Client = ApolloClient__Client;
-  module Graphql = ApolloClient__Graphql;
-  module LinkError = ApolloClient__LinkError;
-  module LinkContext = ApolloClient__LinkContext;
-  module LinkWs = ApolloClient__LinkWs;
-  module SubscriptionTransportWs = ApolloClient__SubscriptionsTransportWs;
-  module ZenObservable = ApolloClient__ZenObservable;
-};
-
+// Caching
 module Cache = {
-  module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache;
   type t('serialized) =
     ApolloClient__Cache_Core_Cache.ApolloCache.t('serialized);
+  // Creating
+  module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache;
+  // Reading and writing
   let readQuery = ApolloClient__Cache_Core_Cache.ApolloCache.readQuery;
   let writeFragment = ApolloClient__Cache_Core_Cache.ApolloCache.writeFragment;
   let writeQuery = ApolloClient__Cache_Core_Cache.ApolloCache.writeQuery;
 };
 
-module GraphQL_PPX = {
-  module ExtendMutation = ApolloClient__React_Hooks_UseMutation.Extend;
-  module ExtendQuery = ApolloClient__React_Hooks_UseQuery.Extend;
-  module ExtendSubscription = ApolloClient__React_Hooks_UseSubscription.Extend;
-  type templateTagReturnType = ApolloClient__Graphql.documentNode;
-};
-
+// Customize Apollo Client's data flow
 module Link = {
   module ContextLink = ApolloClient__LinkContext.ContextLink;
   module ErrorLink = ApolloClient__LinkError.ErrorLink;
@@ -43,35 +53,62 @@ module Link = {
   let split = ApolloClient__Link_Core_ApolloLink.Static.split;
 };
 
-module React = {
-  module ApolloProvider = ApolloClient__React_Context_ApolloProvider;
-  let useApolloClient = ApolloClient__React_Hooks_UseApolloClient.useApolloClient;
-  let useMutation = ApolloClient__React_Hooks_UseMutation.useMutation;
-  let useMutationWithVariables = ApolloClient__React_Hooks_UseMutation.useMutationWithVariables;
-  let useLazyQuery = ApolloClient__React_Hooks_UseLazyQuery.useLazyQuery;
-  let useLazyQueryWithVariables = ApolloClient__React_Hooks_UseLazyQuery.useLazyQueryWithVariables;
-  let useQuery = ApolloClient__React_Hooks_UseQuery.useQuery;
-  let useSubscription = ApolloClient__React_Hooks_UseSubscription.useSubscription;
-};
-
+// Helpers and utilities
 module Utilities = ApolloClient__Utilities;
 
-module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions;
-module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions;
-module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions;
-module DefaultOptions = ApolloClient__ApolloClient.DefaultOptions;
+// 1:1 Javascript package structure
+module Bindings = {
+  module Client = ApolloClient__Client;
+  module Graphql = ApolloClient__Graphql;
+  module LinkError = ApolloClient__LinkError;
+  module LinkContext = ApolloClient__LinkContext;
+  module LinkWs = ApolloClient__LinkWs;
+  module SubscriptionTransportWs = ApolloClient__SubscriptionsTransportWs;
+  module ZenObservable = ApolloClient__ZenObservable;
+};
 
-type t = ApolloClient__ApolloClient.t;
-let make = ApolloClient__ApolloClient.make;
-let mutate = ApolloClient__ApolloClient.mutate;
-let query = ApolloClient__ApolloClient.query;
-let readQuery = ApolloClient__ApolloClient.readQuery;
-let watchQuery = ApolloClient__ApolloClient.watchQuery;
-let writeFragment = ApolloClient__ApolloClient.writeFragment;
-let writeQuery = ApolloClient__ApolloClient.writeQuery;
+// Extension modules used by graphql-ppx
+module GraphQL_PPX = {
+  module ExtendMutation = ApolloClient__React_Hooks_UseMutation.Extend;
+  module ExtendQuery = ApolloClient__React_Hooks_UseQuery.Extend;
+  module ExtendSubscription = ApolloClient__React_Hooks_UseSubscription.Extend;
+  type templateTagReturnType = ApolloClient__Graphql.documentNode;
+};
 
-/**
- * Modules below are exposed for convenient access
- */
-module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
-module QueryResult = ApolloClient__React_Types.QueryResult;
+// Convenient access to all types and the methods for working with those types
+module Types = {
+  module ApolloError = ApolloClient__Errors_ApolloError;
+  module ApolloQueryResult = ApolloClient__Core_Types.ApolloQueryResult;
+  module ApolloLink = ApolloClient__Link_Core_ApolloLink;
+  module ApolloCache = ApolloClient__Cache_Core_Cache.ApolloCache;
+  module BaseSubscriptionOptions = ApolloClient__React_Types.BaseSubscriptionOptions;
+  module DataProxy = ApolloClient__Cache_Core_Types.DataProxy;
+  module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy;
+  module FetchPolicy = ApolloClient__Core_WatchQueryOptions.FetchPolicy;
+  module FetchPolicy__noCacheExtracted = ApolloClient__Core_WatchQueryOptions.FetchPolicy__noCacheExtracted;
+  module FragmentMatcher = ApolloClient__Core_LocalState.FragmentMatcher;
+  module GraphqlError = ApolloClient__Graphql_Error_GraphQLError;
+  module FetchResult = ApolloClient__Link_Core_Types.FetchResult;
+  module LazyQueryHookOptions = ApolloClient__React_Types.LazyQueryHookOptions;
+  module MutationHookOptions = ApolloClient__React_Types.MutationHookOptions;
+  module MutationOptions = ApolloClient__Core_WatchQueryOptions.MutationOptions;
+  module MutationQueryReducersMap = ApolloClient__Core_WatchQueryOptions.MutationQueryReducersMap;
+  module MutationTuple = ApolloClient__React_Types.MutationTuple;
+  module MutationTuple__noVariables = ApolloClient__React_Types.MutationTuple__noVariables;
+  module MutationUpdaterFn = ApolloClient__Core_WatchQueryOptions.MutationUpdaterFn;
+  module ObservableQuery = ApolloClient__Core_ObservableQuery.ObservableQuery;
+  module OnSubscriptionDataOptions = ApolloClient__React_Types.OnSubscriptionDataOptions;
+  module OperationVariables = ApolloClient__Core_Types.OperationVariables;
+  module QueryHookOptions = ApolloClient__React_Types.QueryHookOptions;
+  module QueryOptions = ApolloClient__Core_WatchQueryOptions.QueryOptions;
+  module QueryTuple = ApolloClient__React_Types.QueryTuple;
+  module QueryTuple__noVariables = ApolloClient__React_Types.QueryTuple__noVariables;
+  module QueryResult = ApolloClient__React_Types.QueryResult;
+  module PureQueryOptions = ApolloClient__Core_Types.PureQueryOptions;
+  module RefetchQueryDescription = ApolloClient__Core_WatchQueryOptions.RefetchQueryDescription;
+  module Resolvers = ApolloClient__Core_Types.Resolvers;
+  module SubscriptionHookOptions = ApolloClient__React_Types.SubscriptionHookOptions;
+  module UriFunction = ApolloClient__Link_Http_SelectHttpOptionsAndBody.UriFunction;
+  module WatchQueryFetchPolicy = ApolloClient__Core_WatchQueryOptions.WatchQueryFetchPolicy;
+  module WatchQueryOptions = ApolloClient__Core_WatchQueryOptions.WatchQueryOptions;
+};


### PR DESCRIPTION
I took one more pass at the structure of the root module. The ideas is that the root attempts to present a clear structure for everything needed to create, configure, and query with a client. Then, if you have some result and want to call a method or need access to some type to annotate options, everything is available in the `Types` module.

You can see the effect in the examples.