### PR TITLE
Close method for subscriptions-transport-ws

### DIFF
--- a/src/ReasonMLCommunity__ApolloClient.re
+++ b/src/ReasonMLCommunity__ApolloClient.re
@@ -78,14 +78,15 @@ module GraphQL_PPX = {
 
 /** Convenient access to all types and the methods for working with those types */
 module Types = {
-  module RequestHandler = ApolloClient__Link_Core_Types.RequestHandler;
   module ApolloError = ApolloClient__Errors_ApolloError;
   module ApolloQueryResult = ApolloClient__Core_Types.ApolloQueryResult;
   module ApolloLink = ApolloClient__Link_Core_ApolloLink;
   module ApolloCache = ApolloClient__Cache_Core_Cache.ApolloCache;
   module BaseSubscriptionOptions = ApolloClient__React_Types.BaseSubscriptionOptions;
+  module ConnectionParamsOptions = ApolloClient__SubscriptionsTransportWs.ConnectionParamsOptions;
   module DataProxy = ApolloClient__Cache_Core_Types.DataProxy;
   module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy;
+  module ErrorResponse = ApolloClient__Link_Error.ErrorResponse;
   module FetchPolicy = ApolloClient__Core_WatchQueryOptions.FetchPolicy;
   module FetchPolicy__noCacheExtracted = ApolloClient__Core_WatchQueryOptions.FetchPolicy__noCacheExtracted;
   module FetchResult = ApolloClient__Link_Core_Types.FetchResult;
@@ -119,6 +120,7 @@ module Types = {
   module PureQueryOptions = ApolloClient__Core_Types.PureQueryOptions;
   module ReactiveVar = ApolloClient__Cache_InMemory_ReactiveVars.ReactiveVar;
   module RefetchQueryDescription = ApolloClient__Core_WatchQueryOptions.RefetchQueryDescription;
+  module RequestHandler = ApolloClient__Link_Core_Types.RequestHandler;
   module Resolvers = ApolloClient__Core_Types.Resolvers;
   module SubscriptionHookOptions = ApolloClient__React_Types.SubscriptionHookOptions;
   module TypePolicies = ApolloClient__Cache_InMemory_Policies.TypePolicies;

--- a/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.re
+++ b/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.re
@@ -145,6 +145,10 @@ module ClientOptions = {
 };
 
 module SubscriptionClient = {
+  type t;
+
+  type webSocketImpl;
+
   module Js_ = {
     // export declare class SubscriptionClient {
     //     client: any;
@@ -164,7 +168,43 @@ module SubscriptionClient = {
     //     applyMiddlewares(options: OperationOptions): Promise<OperationOptions>;
     //     use(middlewares: Middleware[]): SubscriptionClient;
     // }
-    type t;
+    type nonrec t = t;
+
+    [@bs.new] [@bs.module "subscriptions-transport-ws"]
+    external make:
+      (
+        ~url: string,
+        ~options: ClientOptions.Js_.t=?,
+        ~webSocketImpl: webSocketImpl=?,
+        ~webSocketProtocols: array(string)=?,
+        unit
+      ) =>
+      t =
+      "SubscriptionClient";
+
+    [@bs.send]
+    external close: (t, ~isForced: bool=?, ~closedByUser: bool=?, unit) => unit =
+      "close";
   };
-  type t = Js_.t;
+
+  let make:
+    (
+      ~url: string,
+      ~options: ClientOptions.t=?,
+      ~webSocketImpl: webSocketImpl=?,
+      ~webSocketProtocols: array(string)=?,
+      unit
+    ) =>
+    t =
+    (~url, ~options=?, ~webSocketImpl=?, ~webSocketProtocols=?, ()) => {
+      Js_.make(
+        ~url,
+        ~options=?options->Belt.Option.map(ClientOptions.toJs),
+        ~webSocketImpl?,
+        ~webSocketProtocols?,
+        (),
+      );
+    };
+
+  let close = Js_.close;
 };


### PR DESCRIPTION
Just fleshing out subscriptions transport a little more. Useful if you need to refresh subscriptions in flight with new connectionParams.