### PR TITLE
Add example with input variables

### DIFF
--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.0-beta.22",
-    "bs-platform": "^7.3.2",
+    "bs-platform": "^8.2.0",
     "graphql-client-example-server": "1.2.0",
     "html-webpack-plugin": "^4.3.0",
     "webpack": "^4.43.0",

--- a/EXAMPLES/src/App.re
+++ b/EXAMPLES/src/App.re
@@ -11,6 +11,8 @@ let make = () => {
     <h4> "Mutation"->React.string </h4>
     <Mutation />
     <h4> "Subcription"->React.string </h4>
+    <Mutation_InputVariables />
+    <h4> "Query with Subscription for More"->React.string </h4>
     <Subscription />
     <h4> "Query with Subscription for More"->React.string </h4>
     <Query_SubscribeToMore />

--- a/EXAMPLES/src/hooksUsage/MutationDelete.re
+++ b/EXAMPLES/src/hooksUsage/MutationDelete.re
@@ -1,0 +1,67 @@
+module Cache = ApolloClient.Cache;
+
+module DeleteTodoMutation = [%graphql
+  {|
+      # This has to be ID! and not String! or it will fail silently
+    mutation DeleteTodo ($id:ID!){
+      deleteTodoItem(input: { id: $id }) {
+        deletedTodoItemId
+        clientMutationId
+      }
+    }
+  |}
+];
+
+[@react.component]
+let make = (~id: string) => {
+  let (_, setId) = React.useState(_ => id);
+
+  let (mutate, result) = DeleteTodoMutation.use();
+  let handleSubmit = event => {
+    ReactEvent.Form.preventDefault(event);
+    mutate({id: id})->ignore;
+  };
+  switch (result) {
+  | {called: false} =>
+    <>
+      "Not called... "->React.string
+      <form onSubmit=handleSubmit>
+        <h2> {React.string("Delete Id: " ++ id ++ "?")} </h2>
+        <div className="form-field">
+          <input
+            placeholder=id
+            value=id
+            onChange={event => {
+              let value = event->ReactEvent.Form.target##value;
+              setId(value);
+            }}
+          />
+        </div>
+        <div className="form-field">
+          <input type_="submit" value="Delete ToDo" />
+        </div>
+      </form>
+    </>
+  | {loading: true} => "Loading..."->React.string
+  | {data: Some({deleteTodoItem}), error: None} =>
+    let deletedTodoItemId =
+      deleteTodoItem
+      ->Belt.Option.map(d => d.deletedTodoItemId)
+      ->Belt.Option.getWithDefault(Some(""));
+
+    let deletedTodoItemId =
+      switch (deletedTodoItemId) {
+      | Some(id) => id
+      | None => ""
+      };
+    <p> {React.string("To-Do id: \"" ++ deletedTodoItemId ++ "\" deleted")} </p>;
+  | {error} =>
+    <>
+      "Error loading data"->React.string
+      {switch (error) {
+       | Some(error) => React.string(": " ++ error.message)
+       | None => React.null
+       }}
+    </>
+  };
+};

--- a/EXAMPLES/src/hooksUsage/Mutation_InputVariables.re
+++ b/EXAMPLES/src/hooksUsage/Mutation_InputVariables.re
@@ -1,0 +1,72 @@
+module Cache = ApolloClient.Cache;
+
+module AddTodoMutation = [%graphql
+  {|
+    mutation AddTodo($text: String!) {
+      todo: addTodoSimple(text: $text) {
+        id
+        completed
+        text
+      }
+    }
+  |}
+];
+module TodosQuery = [%graphql
+  {|
+    query TodosQuery {
+      todos: allTodos {
+        id
+        completed
+        text
+      }
+    }
+  |}
+];
+
+[@react.component]
+let make = () => {
+  let (text, setText) = React.useState(_ => "");
+
+  let (mutate, result) = AddTodoMutation.use();
+  let handleSubmit = event => {
+    ReactEvent.Form.preventDefault(event);
+    mutate({text: text})->ignore;
+  };
+  switch (result) {
+  | {called: false} =>
+    <>
+      "Not called... "->React.string
+      <form onSubmit=handleSubmit>
+        <h2> {React.string("Add a new todo")} </h2>
+        <div className="form-field">
+          <input
+            placeholder="Add Next ToDo"
+            required=true
+            value=text
+            onChange={event => {
+              let value = event->ReactEvent.Form.target##value;
+              setText(value);
+            }}
+          />
+        </div>
+        <div className="form-field">
+          <input type_="submit" value="Add To-Do" />
+        </div>
+      </form>
+    </>
+  | {loading: true} => "Loading..."->React.string
+  | {data: Some({todo: {text, id}}), error: None} =>
+    <div>
+      <p> {React.string("To-Do added: \"" ++ text ++ "\"")} </p>
+      <MutationDelete id />
+    </div>
+  | {error} =>
+    <>
+      "Error loading data"->React.string
+      {switch (error) {
+       | Some(error) => React.string(": " ++ error.message)
+       | None => React.null
+       }}
+    </>
+  };
+};


### PR DESCRIPTION
Something going on with git on my machine,(or I screwed something up), so redid #37 here. Sorry for the inconvience. Your comments are reproduced here.

> Thanks for the contribution! I haven't been able to look at this yet, but a couple things before I do:
> 
>     1. Could you look at the `package.json` changes and confirm everything there is intentional?
> 
>     2. Could you remove the `yarn.lock` files, I thought I'd added that to `.gitignore`, but I guess not
> 
>     3. I would have expected the current mutation examples to include variables. Do they really not? If they do use variables, what are these examples showing that they do not?
> 
> 
> Thanks, again! I'll try and get to this soon.


The only change now in `package.json` is updating `bs-platform` to `8.2.0`. I wanted to see if that was causing the `ID!` or `String!` issue and left it. 

`yarn.lock` is no longer in diff.

The current examples have the variables hard coded which doesn't require you to think through how you would use and pass them. For whatever reason, I had to see this to get my head around passing variables, building queries in a migration I am doing to this client. Might just be me.

Regarding the issue of passing and `ID!` or `String!`, with all the proper dependencies in the repo, we are still getting it. I will ask @jfrolich about it.

Again, coming from the migration experience, I think its useful to have an example where you are pulling multiple variables out of your response if only just to see it.

Either way, I am not attached to this PR if you feel it doesn't help. I did it to figure some things out and figured I would share it as it helped me.

Thanks to you and @jfrolich for this excellent work. I will make this a draft.
