### PR TITLE
Expose SubscriptionClient from WebSocketLink

### DIFF
--- a/src/@apollo/client/link/ws/ApolloClient__Link_Ws.re
+++ b/src/@apollo/client/link/ws/ApolloClient__Link_Ws.re
@@ -1,9 +1,10 @@
 module ApolloLink = ApolloClient__Link_Core_ApolloLink;
 module Graphql = ApolloClient__Graphql;
-module SubscriptionClient = ApolloClient__SubscriptionsTransportWs.SubscriptionClient;
 
 module WebSocketLink = {
   module ClientOptions = ApolloClient__SubscriptionsTransportWs.ClientOptions;
+  module SubscriptionClient = ApolloClient__SubscriptionsTransportWs.SubscriptionClient;
+
   module Configuration = {
     module Js_ = {
       // export declare namespace WebSocketLink {


### PR DESCRIPTION
When you're using `Link.WebSocket.makeWithSubscriptionClient` it's a bit hard to know where to get the subscription client without going through the `Bindings` path.