### PR TITLE
Results and Promises

### DIFF
--- a/EXAMPLES/bsconfig.json
+++ b/EXAMPLES/bsconfig.json
@@ -30,7 +30,6 @@
   "bs-dependencies": [
     "reason-apollo-client",
     "@reasonml-community/graphql-ppx",
-    "@yawaramin/prometo",
     "reason-promise",
     "reason-react"
   ]

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -24,7 +24,7 @@
     "graphql": "^14.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "reason-apollo-client": "0.0.1-beta.7",
+    "reason-apollo-client": "../",
     "reason-promise": "1.1.1",
     "reason-react": "0.9.1",
     "subscriptions-transport-ws": "0.9.16"

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -20,11 +20,10 @@
   },
   "dependencies": {
     "@apollo/client": "3.1.4",
-    "@yawaramin/prometo": "0.11.0",
     "graphql": "^14.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "reason-apollo-client": "../",
+    "reason-apollo-client": "^0.0.1-beta.8",
     "reason-promise": "1.1.1",
     "reason-react": "0.9.1",
     "subscriptions-transport-ws": "0.9.16"

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -1,6 +1,5 @@
 module ApolloQueryResult = ApolloClient.Types.ApolloQueryResult;
 module ObservableQuery = ApolloClient.Types.ObservableQuery;
-module Prometo = Yawaramin__Prometo;
 
 module AddTodoMutation = [%graphql
   {|

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -40,26 +40,25 @@ let addTodo = _ =>
       ~mutation=(module AddTodoMutation),
       {text: "Another To-Do"},
     )
-  ->Promise.Js.fromBsPromise
-  ->Promise.Js.toResult
   ->Promise.get(
       fun
-      | Ok(result) => Js.log2("mutate result: ", result.data)
-      | Error(error) => Js.log2("Error: ", error),
+      | {data: Some(data), error: None} => Js.log2("mutate result: ", data)
+      | {error} => Js.log2("Error: ", error),
     );
 
+let observableQuery =
+  Client.instance->ApolloClient.watchQuery(~query=(module TodosQuery), ());
+
 let watchQuerySubscription =
-  Client.instance
-  ->ApolloClient.watchQuery(~query=(module TodosQuery), ())
-  ->ObservableQuery.subscribe(
-      ~onNext=
-        result =>
-          switch (result) {
-          | {data: Some({todos})} => Js.log2("watchQuery To-Dos: ", todos)
-          | _ => ()
-          },
-      (),
-    );
+  observableQuery.subscribe(
+    ~onNext=
+      result =>
+        switch (result) {
+        | {data: Some({todos})} => Js.log2("watchQuery To-Dos: ", todos)
+        | _ => ()
+        },
+    (),
+  );
 // Unsubscribe like so:
 // watchQuerySubscription->ApolloClient.ObservableQuery.Subscription.unsubscribe;
 

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -35,43 +35,6 @@ let logTodos = _ =>
       | {error} => Js.log2("Error: ", error),
     );
 
-// let logTodos_good_prometo = _ =>
-//   Client.instance
-//   ->ApolloClient.query(~query=(module TodosQuery), ())
-//   ->Prometo.fromPromise
-//   ->Prometo.handle(~f=result => {
-//       switch (result) {
-//       | Ok({data: Some({todos})}) => Js.log2("query To-Dos: ", todos)
-//       | Ok(_) => Js.log("Error: no To-Dos!")
-//       | Error(error) => Js.log2("Error: ", error)
-//       };
-//       result;
-//     })
-//   ->ignore;
-
-// /**
-//  * The ergonomics of the Js module promise methods are such that the compiler cannot
-//  * infer the type of result which means the record fields are not in scope, forcing you
-//  * to annotate it. I would highly recommend using one of the promise libraries above!
-//  */
-// let logTodos_bad_jsPromise = _ =>
-//   Client.instance
-//   ->ApolloClient.query(~query=(module TodosQuery), ())
-//   ->Js.Promise.then_(
-//       (result: ApolloQueryResult.t(_)) =>
-//         switch (result) {
-//         | {data: Some({TodosQuery.todos})} =>
-//           Js.Promise.resolve(Js.log2("query To-Dos: ", todos))
-//         | _ => Js.Exn.raiseError("Error: no people!")
-//         },
-//       _,
-//     )
-//   ->Js.Promise.catch(
-//       eeyore => Js.Promise.resolve(Js.log2("Error: ", eeyore)),
-//       _,
-//     )
-//   ->ignore;
-
 let addTodo = _ =>
   Client.instance
   ->ApolloClient.mutate(
@@ -109,16 +72,6 @@ let make = () => {
         "Log To-Dos (Reason Promise)"->React.string
       </button>
     </p>
-    // <p>
-    //   <button onClick=logTodos_good_prometo>
-    //     "Log To-Dos (Prometo)"->React.string
-    //   </button>
-    // </p>
-    // <p>
-    //   <button onClick=logTodos_bad_jsPromise>
-    //     "Log To-Dos (Js Module)"->React.string
-    //   </button>
-    // </p>
     <p> <button onClick=addTodo> "Add To-Do"->React.string </button> </p>
     <p> "[ To-Dos also logged in console with watchQuery ]"->React.string </p>
   </div>;

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -25,54 +25,52 @@ module TodosQuery = [%graphql
   |}
 ];
 
-let logTodos_good_reasonPromise = _ =>
+let logTodos = _ =>
   Client.instance
   ->ApolloClient.query(~query=(module TodosQuery), ())
-  ->Promise.Js.fromBsPromise
-  ->Promise.Js.toResult
   ->Promise.get(
       fun
-      | Ok({data: Some({todos})}) => Js.log2("query To-Dos: ", todos)
-      | Ok(_) => Js.log("Error: no To-Dos!")
-      | Error(error) => Js.log2("Error: ", error),
+      | {data: Some({todos}), error: None} =>
+        Js.log2("query To-Dos: ", todos)
+      | {error} => Js.log2("Error: ", error),
     );
 
-let logTodos_good_prometo = _ =>
-  Client.instance
-  ->ApolloClient.query(~query=(module TodosQuery), ())
-  ->Prometo.fromPromise
-  ->Prometo.handle(~f=result => {
-      switch (result) {
-      | Ok({data: Some({todos})}) => Js.log2("query To-Dos: ", todos)
-      | Ok(_) => Js.log("Error: no To-Dos!")
-      | Error(error) => Js.log2("Error: ", error)
-      };
-      result;
-    })
-  ->ignore;
+// let logTodos_good_prometo = _ =>
+//   Client.instance
+//   ->ApolloClient.query(~query=(module TodosQuery), ())
+//   ->Prometo.fromPromise
+//   ->Prometo.handle(~f=result => {
+//       switch (result) {
+//       | Ok({data: Some({todos})}) => Js.log2("query To-Dos: ", todos)
+//       | Ok(_) => Js.log("Error: no To-Dos!")
+//       | Error(error) => Js.log2("Error: ", error)
+//       };
+//       result;
+//     })
+//   ->ignore;
 
-/**
- * The ergonomics of the Js module promise methods are such that the compiler cannot
- * infer the type of result which means the record fields are not in scope, forcing you
- * to annotate it. I would highly recommend using one of the promise libraries above!
- */
-let logTodos_bad_jsPromise = _ =>
-  Client.instance
-  ->ApolloClient.query(~query=(module TodosQuery), ())
-  ->Js.Promise.then_(
-      (result: ApolloQueryResult.t(_)) =>
-        switch (result) {
-        | {data: Some({TodosQuery.todos})} =>
-          Js.Promise.resolve(Js.log2("query To-Dos: ", todos))
-        | _ => Js.Exn.raiseError("Error: no people!")
-        },
-      _,
-    )
-  ->Js.Promise.catch(
-      eeyore => Js.Promise.resolve(Js.log2("Error: ", eeyore)),
-      _,
-    )
-  ->ignore;
+// /**
+//  * The ergonomics of the Js module promise methods are such that the compiler cannot
+//  * infer the type of result which means the record fields are not in scope, forcing you
+//  * to annotate it. I would highly recommend using one of the promise libraries above!
+//  */
+// let logTodos_bad_jsPromise = _ =>
+//   Client.instance
+//   ->ApolloClient.query(~query=(module TodosQuery), ())
+//   ->Js.Promise.then_(
+//       (result: ApolloQueryResult.t(_)) =>
+//         switch (result) {
+//         | {data: Some({TodosQuery.todos})} =>
+//           Js.Promise.resolve(Js.log2("query To-Dos: ", todos))
+//         | _ => Js.Exn.raiseError("Error: no people!")
+//         },
+//       _,
+//     )
+//   ->Js.Promise.catch(
+//       eeyore => Js.Promise.resolve(Js.log2("Error: ", eeyore)),
+//       _,
+//     )
+//   ->ignore;
 
 let addTodo = _ =>
   Client.instance
@@ -107,20 +105,20 @@ let watchQuerySubscription =
 let make = () => {
   <div>
     <p>
-      <button onClick=logTodos_good_reasonPromise>
+      <button onClick=logTodos>
         "Log To-Dos (Reason Promise)"->React.string
       </button>
     </p>
-    <p>
-      <button onClick=logTodos_good_prometo>
-        "Log To-Dos (Prometo)"->React.string
-      </button>
-    </p>
-    <p>
-      <button onClick=logTodos_bad_jsPromise>
-        "Log To-Dos (Js Module)"->React.string
-      </button>
-    </p>
+    // <p>
+    //   <button onClick=logTodos_good_prometo>
+    //     "Log To-Dos (Prometo)"->React.string
+    //   </button>
+    // </p>
+    // <p>
+    //   <button onClick=logTodos_bad_jsPromise>
+    //     "Log To-Dos (Js Module)"->React.string
+    //   </button>
+    // </p>
     <p> <button onClick=addTodo> "Add To-Do"->React.string </button> </p>
     <p> "[ To-Dos also logged in console with watchQuery ]"->React.string </p>
   </div>;

--- a/EXAMPLES/src/hooksUsage/Query_Typical.re
+++ b/EXAMPLES/src/hooksUsage/Query_Typical.re
@@ -55,7 +55,11 @@ let make = () => {
                      },
                    (),
                  )
-               ->ignore
+               ->Promise.get(({error}) =>
+                   if (error->Belt.Option.isSome) {
+                     Js.log2("Failed to fetch more: ", error);
+                   }
+                 )
              }>
              "Fetch More!"->React.string
            </button>

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -17,5 +17,9 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@reasonml-community/graphql-ppx", "reason-react"]
+  "bs-dependencies": [
+    "@reasonml-community/graphql-ppx",
+    "reason-promise",
+    "reason-react"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "^7.3.0 || ^8.0.0",
     "reason-react": "^0.8.0 || ^0.9.0"
+  },
+  "dependencies": {
+    "reason-promise": "1.1.1"
   }
 }

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -634,11 +634,14 @@ let readQuery:
     ~optimistic=?,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
-
     Js_.readQuery(
       client,
-      ~options={id, query: Operation.query, variables: jsVariables},
+      ~options=
+        DataProxy.Query.toJs(
+          {id, query: Operation.query, variables},
+          ~mapJsVariables,
+          ~serializeVariables=Operation.serializeVariables,
+        ),
       ~optimistic,
     )
     ->Js.toOption
@@ -674,6 +677,7 @@ let watchQuery:
     variables,
   ) => {
     let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     Js_.watchQuery(
       client,
@@ -686,7 +690,7 @@ let watchQuery:
           context,
         }),
     )
-    ->ObservableQuery.fromJs(~parse=Operation.parse);
+    ->ObservableQuery.fromJs(~safeParse);
   };
 
 let writeFragment:
@@ -712,13 +716,11 @@ let writeFragment:
   ) => {
     Js_.writeFragment(
       client,
-      ~options={
-        broadcast,
-        data: data->Fragment.serialize,
-        id,
-        fragment: Fragment.query,
-        fragmentName,
-      },
+      ~options=
+        DataProxy.WriteFragmentOptions.toJs(
+          {broadcast, data, id, fragment: Fragment.query, fragmentName},
+          ~serialize=Fragment.serialize,
+        ),
     );
   };
 
@@ -746,16 +748,14 @@ let writeQuery:
     ~mapJsVariables=Utils.identity,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
-
     Js_.writeQuery(
       client,
-      ~options={
-        broadcast,
-        data: data->Operation.serialize,
-        id,
-        query: Operation.query,
-        variables: jsVariables,
-      },
+      ~options=
+        DataProxy.WriteQueryOptions.toJs(
+          {broadcast, data, id, query: Operation.query, variables},
+          ~mapJsVariables,
+          ~serialize=Operation.serialize,
+          ~serializeVariables=Operation.serializeVariables,
+        ),
     );
   };

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -484,6 +484,7 @@ let mutate:
     variables,
   ) => {
     let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     Js_.mutate(
       client,
@@ -501,15 +502,13 @@ let mutate:
             update,
             variables: jsVariables,
           },
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
         ),
     )
     ->Js.Promise.then_(
         jsResult =>
-          jsResult
-          ->FetchResult.fromJs(_, ~parse=Operation.parse)
-          ->Js.Promise.resolve,
+          jsResult->FetchResult.fromJs(_, ~safeParse)->Js.Promise.resolve,
         _,
       );
   };
@@ -544,6 +543,7 @@ let query:
     variables,
   ) => {
     let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     Js_.query(
       client,
@@ -561,9 +561,7 @@ let query:
     ->Promise.map(result => {
         switch (result) {
         | Ok(jsApolloQueryResult) =>
-          jsApolloQueryResult->ApolloQueryResult.fromJs(
-            ~parse=Operation.parse,
-          )
+          jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse)
         | Error(error) =>
           ApolloQueryResult.fromError(
             ApolloError.make(

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -518,12 +518,13 @@ let onClearStore = Js_.onClearStore;
 let onResetStore = Js_.onResetStore;
 
 let query:
-  type data variables jsVariables.
+  type data jsData variables jsVariables.
     (
       t,
       ~query: (module Operation with
                  type t = data and
                  type t_variables = variables and
+                 type Raw.t = jsData and
                  type Raw.t_variables = jsVariables),
       ~context: Js.Json.t=?,
       ~errorPolicy: ErrorPolicy.t=?,

--- a/src/@apollo/client/cache/core/types/ApolloClient__Cache_Core_Types_DataProxy.re
+++ b/src/@apollo/client/cache/core/types/ApolloClient__Cache_Core_Types_DataProxy.re
@@ -1,4 +1,5 @@
 module Graphql = ApolloClient__Graphql;
+module Utils = ApolloClient__Utils;
 
 module Query = {
   module Js_ = {
@@ -16,6 +17,19 @@ module Query = {
   };
 
   type t('jsVariables) = Js_.t('jsVariables);
+
+  let toJs:
+    (
+      t('variables),
+      ~mapJsVariables: 'jsVariables => 'jsVariables=?,
+      ~serializeVariables: 'variables => 'jsVariables
+    ) =>
+    Js_.t('jsVariables) =
+    (t, ~mapJsVariables=Utils.identity, ~serializeVariables) => {
+      query: t.query,
+      variables: t.variables->serializeVariables->mapJsVariables,
+      id: t.id,
+    };
 };
 
 module Fragment = {
@@ -55,22 +69,27 @@ module WriteQueryOptions = {
     };
   };
 
-  type t('data, 'jsVariables) = {
+  type t('data, 'variables) = {
     data: 'data,
     broadcast: option(bool),
     query: Graphql.documentNode,
-    variables: 'jsVariables,
+    variables: 'variables,
     id: option(string),
   };
 
   let toJs:
-    (t('data, 'jsVariables), ~parse: 'jsData => 'data) =>
+    (
+      t('data, 'variables),
+      ~mapJsVariables: 'jsVariables => 'jsVariables=?,
+      ~serialize: 'data => 'jsData,
+      ~serializeVariables: 'variables => 'jsVariables
+    ) =>
     Js_.t('jsData, 'jsVariables) =
-    (t, ~parse) => {
-      data: t.data->parse,
+    (t, ~mapJsVariables=Utils.identity, ~serialize, ~serializeVariables) => {
+      data: t.data->serialize,
       broadcast: t.broadcast,
       query: t.query,
-      variables: t.variables,
+      variables: t.variables->serializeVariables->mapJsVariables,
       id: t.id,
     };
 };
@@ -94,22 +113,29 @@ module WriteFragmentOptions = {
     };
   };
 
-  type t('data, 'jsVariables) = {
+  type t('data, 'variables) = {
     data: 'data,
     broadcast: option(bool),
     id: string,
     fragment: Graphql.documentNode,
     fragmentName: option(string),
+    // variables: 'variables,
   };
 
   let toJs:
-    (t('data, 'jsVariables), ~parse: 'jsData => 'data) =>
+    (
+      t('data, 'variables),
+      // ~mapJsVariables: 'jsVariables => 'jsVariables=?,
+      ~serialize: 'data => 'jsData
+    ) =>
+    // ~serializeVariables: 'variables => 'jsVariables
     Js_.t('jsData, 'jsVariables) =
-    (t, ~parse) => {
-      data: t.data->parse,
+    (t, ~serialize) => {
+      data: t.data->serialize,
       broadcast: t.broadcast,
       id: t.id,
       fragment: t.fragment,
       fragmentName: t.fragmentName,
+      // variables: t.variables->serializeVariables->mapJsVariables,
     };
 };

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
@@ -1,3 +1,5 @@
+module Types = ApolloClient__Types;
+
 module ObservableQuery = {
   module ApolloQueryResult = ApolloClient__Core_Types.ApolloQueryResult;
   module Subscription = ApolloClient__ZenObservable.Subscription;
@@ -50,6 +52,36 @@ module ObservableQuery = {
     // ...extends Observable<ApolloQueryResult<TData>>
     // <R>(callback: (value: T) => R): Observable<R>;
     [@bs.send] external map: (t('t), 't => 'r) => t('r) = "map";
+    let fakeMap: (t('t), 't => 'r) => t('r) =
+      (js, fn) =>
+        /**
+          * We should be able to just map, but it's broken:
+          * https://github.com/apollographql/apollo-client/issues/6144
+          * This is not any sort of real map, of course. It just returns an observable
+          * with a subcribe method that builds the transformation into onNext :(
+          */
+        {
+          [%raw
+            {|
+            function (js, fn) {
+              var originalSubscribe = js.subscribe.bind(js);
+              js.subscribe = function (onNext, onError, onComplete) {
+                var newOnNext = function (result) {
+                  var transformedResult = result.data
+                    ? Object.assign({}, result, { data: fn(result.data) })
+                    : result;
+                  return onNext(transformedResult);
+                };
+                return originalSubscribe(newOnNext, onError, onComplete);
+              };
+              return js;
+            }
+          |}
+          ](
+            js,
+            fn,
+          );
+        };
 
     // ...extends Observable<ApolloQueryResult<TData>>
     // (onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
@@ -66,60 +98,52 @@ module ObservableQuery = {
       "subscribe";
   };
 
-  type t('data);
+  type t('data) = {
+    map: 'mappedData. ('data => 'mappedData) => t('mappedData),
+    subscribe:
+      (
+        ~onNext: ApolloQueryResult.t('data) => unit,
+        ~onError: Js.Json.t => unit=?,
+        ~onComplete: unit => unit=?,
+        unit
+      ) =>
+      Subscription.t,
+  };
 
   external castFromJs: Js_.t('data) => t('data) = "%identity";
 
   external castToJs: t('data) => Js_.t('data) = "%identity";
 
-  let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
-    (js, ~parse) => {
-      // Lovely. We should be able to just map, but it's broken:
-      // https://github.com/apollographql/apollo-client/issues/6144
-      // js->Js_.map(ApolloQueryResult.fromJs(~parse))->castFromJs;
-      [%raw
-        {|
-          function (js, parse) {
-            var originalSubscribe = js.subscribe.bind(js);
-            js.subscribe = function (onNext, onError, onComplete) {
-              var newOnNext = function (result) {
-                var parsedResult = result.data
-                  ? Object.assign({}, result, { data: parse(result.data) })
-                  : result;
-                return onNext(parsedResult);
-              };
-              return originalSubscribe(newOnNext, onError, onComplete);
-            };
-            return js;
+  let fromJs:
+    (Js_.t('jsData), ~safeParse: Types.safeParse('data, 'jsData)) =>
+    t('data) =
+    (js, ~safeParse) => {
+      let observableWithParsedData =
+        js->Js_.fakeMap(jsData =>
+          switch (safeParse(jsData)) {
+          | Data(data) => data
+          | ParseError(_error) =>
+            Js.Exn.raiseError(
+              "OMG, Becky. There was a parse error in an observable",
+            )
           }
-        |}
-      ](
-        js,
-        parse,
-      );
+        );
+      {
+        map: f => {
+          observableWithParsedData->Js_.fakeMap(f)->castFromJs;
+        },
+
+        subscribe: (~onNext, ~onError=?, ~onComplete=?, ()) =>
+          js->Js_.subscribe(
+            ~onNext=
+              jsApolloQueryResult =>
+                onNext(
+                  jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse),
+                ),
+            ~onError?,
+            ~onComplete?,
+            (),
+          ),
+      };
     };
-
-  [@bs.send] external map: (t('a), 'a => 'b) => t('b) = "map";
-
-  let subscribe:
-    (
-      t('data),
-      ~onNext: ApolloQueryResult.t('data) => unit,
-      ~onError: Js.Json.t => unit=?,
-      ~onComplete: unit => unit=?,
-      unit
-    ) =>
-    Subscription.t =
-    (t, ~onNext, ~onError=?, ~onComplete=?, ()) =>
-      /**
-       * Ugh, this diverges from normal patterns because data in these callbacks has to be parsed before this point.
-       * I wonder if there is a way we could pass parse along and then use it here or maybe there is a better pattern for this.
-       */
-      Js_.subscribe(
-        t->castToJs,
-        ~onNext=Obj.magic(onNext),
-        ~onError?,
-        ~onComplete?,
-        (),
-      );
 };

--- a/src/@apollo/client/core/ApolloClient__Core_Types.re
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.re
@@ -70,34 +70,11 @@ module ApolloQueryResult = {
   let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
     (js, ~parse) => {
       let (data, error) =
-        switch (
-          js.data->Belt.Option.map(jsData => Utils.safeParse(parse, jsData))
-        ) {
-        | Some(Data(data)) => (
-            Some(data),
-            js.errors
-            ->Belt.Option.map(errors =>
-                ApolloError.make(~graphQLErrors=errors, ())
-              ),
-          )
-        | Some(ParseError({data})) => (
-            None,
-            Some(
-              ApolloError.make(
-                ~networkError=ParseError({data: data}),
-                ~graphQLErrors=?js.errors,
-                (),
-              ),
-            ),
-          )
-        | None => (
-            None,
-            js.errors
-            ->Belt.Option.map(errors =>
-                ApolloError.make(~graphQLErrors=errors, ())
-              ),
-          )
-        };
+        Utils.safeParseWithCommonProps(
+          ~jsData=js.data,
+          ~graphQLErrors=?js.errors,
+          parse,
+        );
 
       {data, error, loading: js.loading, networkStatus: js.networkStatus};
     };

--- a/src/@apollo/client/core/ApolloClient__Core_Types.re
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.re
@@ -1,6 +1,7 @@
 module ApolloError = ApolloClient__Errors_ApolloError;
 module Graphql = ApolloClient__Graphql;
 module FetchResult = ApolloClient__Link_Core_Types.FetchResult;
+module NetworkStatus = ApolloClient__Core_NetworkStatus.NetworkStatus;
 module Resolver = ApolloClient__Core_LocalState.Resolver;
 module Types = ApolloClient__Types;
 module Utils = ApolloClient__Utils;
@@ -64,7 +65,7 @@ module ApolloQueryResult = {
      */
     error: option(ApolloError.t),
     loading: bool,
-    networkStatus: int,
+    networkStatus: NetworkStatus.t,
   };
 
   let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
@@ -76,7 +77,20 @@ module ApolloQueryResult = {
           parse,
         );
 
-      {data, error, loading: js.loading, networkStatus: js.networkStatus};
+      {
+        data,
+        error,
+        loading: js.loading,
+        networkStatus: js.networkStatus->NetworkStatus.fromJs,
+      };
+    };
+
+  let fromError: ApolloError.t => t('data) =
+    error => {
+      data: None,
+      error: Some(error),
+      loading: false,
+      networkStatus: Error,
     };
 };
 

--- a/src/@apollo/client/core/ApolloClient__Core_Types.re
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.re
@@ -73,7 +73,7 @@ module ApolloQueryResult = {
     t('data) =
     (js, ~safeParse) => {
       let (data, error) =
-        Utils.safeParseWithCommonProps(
+        Utils.safeParseAndLiftToCommonResultProps(
           ~jsData=js.data,
           ~graphQLErrors=?js.errors,
           safeParse,

--- a/src/@apollo/client/core/ApolloClient__Core_Types.re
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.re
@@ -68,13 +68,15 @@ module ApolloQueryResult = {
     networkStatus: NetworkStatus.t,
   };
 
-  let fromJs: (Js_.t('jsData), ~parse: 'jsData => 'data) => t('data) =
-    (js, ~parse) => {
+  let fromJs:
+    (Js_.t('jsData), ~safeParse: Types.safeParse('data, 'jsData)) =>
+    t('data) =
+    (js, ~safeParse) => {
       let (data, error) =
         Utils.safeParseWithCommonProps(
           ~jsData=js.data,
           ~graphQLErrors=?js.errors,
-          parse,
+          safeParse,
         );
 
       {
@@ -119,15 +121,15 @@ module MutationQueryReducer = {
   type t('data) = (Js.Json.t, options('data)) => Js.Json.t;
 
   let toJs:
-    (t('data), ~parse: 'jsData => 'data) =>
+    (t('data), ~safeParse: Types.safeParse('data, 'jsData)) =>
     (. Js.Json.t, Js_.options('jsData)) => Js.Json.t =
-    (t, ~parse) =>
+    (t, ~safeParse) =>
       (. previousResult, jsOptions) =>
         t(
           previousResult,
           {
             mutationResult:
-              jsOptions.mutationResult->FetchResult.fromJs(~parse),
+              jsOptions.mutationResult->FetchResult.fromJs(~safeParse),
             queryName: jsOptions.queryName,
             queryVariables: jsOptions.queryVariables,
           },
@@ -146,11 +148,13 @@ module MutationQueryReducersMap = {
 
   type t('data) = Js.Dict.t(MutationQueryReducer.t('data));
 
-  let toJs: (t('data), ~parse: 'jsData => 'data) => Js_.t('jsData) =
-    (t, ~parse) => {
+  let toJs:
+    (t('data), ~safeParse: Types.safeParse('data, 'jsData)) =>
+    Js_.t('jsData) =
+    (t, ~safeParse) => {
       Js.Dict.map(
         (. mutationQueryReducer) =>
-          mutationQueryReducer->MutationQueryReducer.toJs(~parse),
+          mutationQueryReducer->MutationQueryReducer.toJs(~safeParse),
         t,
       );
     };

--- a/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
+++ b/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.re
@@ -2,6 +2,7 @@ module Graphql = ApolloClient__Graphql;
 module GraphQLError = ApolloClient__Graphql.Error.GraphQLError;
 module ServerError = ApolloClient__Link_Utils_ThrowServerError.ServerError;
 module ServerParseError = ApolloClient__Link_Http_ParseAndCheckHttpResponse.ServerParseError;
+module Types = ApolloClient__Types;
 
 module Js_ = {
   module NetworkErrorUnion: {
@@ -83,7 +84,7 @@ type t_networkError =
   /* Fetch got a response, but it wasn't JSON */
   | BadBody(ServerParseError.t)
   /* We got a JSON response, but it wasn't in a shape we could parse */
-  | ParseError({data: Js.Json.t}); // ParseError is reason-apollo-client only
+  | ParseError(Types.parseError); // ParseError is reason-apollo-client only
 
 type t = {
   extraInfo: Js.Json.t,

--- a/src/@apollo/client/link/context/ApolloClient__Link_Context.re
+++ b/src/@apollo/client/link/context/ApolloClient__Link_Context.re
@@ -1,22 +1,42 @@
 module ApolloLink = ApolloClient__Link_Core_ApolloLink;
 module GraphQLRequest = ApolloClient__Link_Core_Types.GraphQLRequest;
 
-// export declare type ContextSetter = (operation: GraphQLRequest, prevContext: any) => Promise<any> | any;
-// export declare function setContext(setter: ContextSetter): ApolloLink;
-[@bs.module "@apollo/client/link/context"]
-external setContext:
-  ((~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) => Js.Json.t) =>
-  ApolloLink.t =
-  "setContext";
+module Js_ = {
+  // export declare type ContextSetter = (operation: GraphQLRequest, prevContext: any) => Promise<any> | any;
+  // export declare function setContext(setter: ContextSetter): ApolloLink;
+  [@bs.module "@apollo/client/link/context"]
+  external setContext:
+    ((~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) => Js.Json.t) =>
+    ApolloLink.t =
+    "setContext";
 
-[@bs.module "@apollo/client/link/context"]
-external setContextAsync:
+  [@bs.module "@apollo/client/link/context"]
+  external setContextAsync:
+    (
+      (~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) =>
+      Js.Promise.t(Js.Json.t)
+    ) =>
+    ApolloLink.t =
+    "setContext";
+
+  type asyncJs =
+    (~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) =>
+    Js.Promise.t(Js.Json.t);
+  type async =
+    (~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) =>
+    Promise.t(Js.Json.t);
+  external safeCastAsync: async => asyncJs = "%identity";
+};
+
+let setContext = Js_.setContext;
+
+let setContextAsync:
   (
     (~operation: GraphQLRequest.t, ~prevContext: Js.Json.t) =>
-    Js.Promise.t(Js.Json.t)
+    Promise.t(Js.Json.t)
   ) =>
   ApolloLink.t =
-  "setContext";
+  fn => Js_.setContextAsync(Js_.safeCastAsync(fn));
 
 // reason-specific
 module ContextLink = {

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
@@ -93,7 +93,7 @@ module FetchResult = {
     t('data) =
     (js, ~safeParse) => {
       let (data, error) =
-        Utils.safeParseWithCommonProps(
+        Utils.safeParseAndLiftToCommonResultProps(
           ~jsData=js.data->Js.toOption,
           ~graphQLErrors=?js.errors,
           safeParse,

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
@@ -100,6 +100,14 @@ module FetchResult = {
         );
       {data, error, extensions: js.extensions, context: js.context};
     };
+
+  let fromError: ApolloError.t => t('data) =
+    error => {
+      data: None,
+      extensions: None,
+      context: None,
+      error: Some(error),
+    };
 };
 
 module NextLink = {

--- a/src/@apollo/client/link/error/ApolloClient__Link_Error.re
+++ b/src/@apollo/client/link/error/ApolloClient__Link_Error.re
@@ -71,10 +71,9 @@ module ErrorResponse = {
   };
 
   type t_networkError =
-    ApolloError.t_networkError =
-      | FetchFailure(Js.Exn.t)
-      | BadStatus(int, ServerError.t)
-      | BadBody(ServerParseError.t);
+    | FetchFailure(Js.Exn.t)
+    | BadStatus(int, ServerError.t)
+    | BadBody(ServerParseError.t);
 
   type t = {
     graphQLErrors: option(array(GraphQLError.t)),

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
@@ -20,7 +20,7 @@ module Js_ = {
       . Graphql.documentNode,
       LazyQueryHookOptions.Js_.t('jsData, 'jsVariables)
     ) =>
-    QueryTuple.Js_.t('jsData, 'variables, 'jsVariables) =
+    QueryTuple.Js_.t('jsData, 'jsVariables) =
     "useLazyQuery";
 };
 
@@ -82,6 +82,7 @@ let useLazyQuery:
             variables: None,
           },
           ~safeParse,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 
@@ -119,7 +120,7 @@ let useLazyQueryWithVariables:
       ~ssr: bool=?,
       variables
     ) =>
-    QueryTuple__noVariables.t(data, jsData, jsVariables) =
+    QueryTuple__noVariables.t(data, jsData, variables, jsVariables) =
   (
     ~query as (module Operation),
     ~client=?,
@@ -136,7 +137,6 @@ let useLazyQueryWithVariables:
     ~ssr=?,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
     let safeParse = Utils.safeParse(Operation.parse);
 
     let jsQueryTuple =
@@ -156,19 +156,22 @@ let useLazyQueryWithVariables:
             pollInterval,
             query: None,
             ssr,
-            variables: Some(jsVariables),
+            variables: Some(variables),
           },
           ~safeParse,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 
     Utils.useGuaranteedMemo1(
       () => {
         jsQueryTuple->QueryTuple__noVariables.fromJs(
+          ~mapJsVariables,
           ~safeParse,
           ~serialize=Operation.serialize,
+          ~serializeVariables=Operation.serializeVariables,
           // Passing in the same variables from above allows us to reuse some types
-          ~variables=jsVariables,
+          ~variables,
         )
       },
       jsQueryTuple,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.re
@@ -38,7 +38,7 @@ let useLazyQuery:
       ~errorPolicy: ErrorPolicy.t=?,
       ~fetchPolicy: WatchQueryFetchPolicy.t=?,
       ~notifyOnNetworkStatusChange: bool=?,
-      ~onCompleted: data => unit=?,
+      ~onCompleted: Types.parseResult(data) => unit=?,
       ~onError: ApolloError.t => unit=?,
       ~partialRefetch: bool=?,
       ~pollInterval: int=?,
@@ -61,6 +61,7 @@ let useLazyQuery:
     ~ssr=?,
     (),
   ) => {
+    let safeParse = Utils.safeParse(Operation.parse);
     let jsQueryTuple =
       Js_.useLazyQuery(.
         Operation.query,
@@ -80,14 +81,14 @@ let useLazyQuery:
             ssr,
             variables: None,
           },
-          ~parse=Operation.parse,
+          ~safeParse,
         ),
       );
 
     Utils.useGuaranteedMemo1(
       () => {
         jsQueryTuple->QueryTuple.fromJs(
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
           ~serializeVariables=Operation.serializeVariables,
         )
@@ -111,7 +112,7 @@ let useLazyQueryWithVariables:
       ~fetchPolicy: WatchQueryFetchPolicy.t=?,
       ~mapJsVariables: jsVariables => jsVariables=?,
       ~notifyOnNetworkStatusChange: bool=?,
-      ~onCompleted: data => unit=?,
+      ~onCompleted: Types.parseResult(data) => unit=?,
       ~onError: ApolloError.t => unit=?,
       ~partialRefetch: bool=?,
       ~pollInterval: int=?,
@@ -135,8 +136,8 @@ let useLazyQueryWithVariables:
     ~ssr=?,
     variables,
   ) => {
-    let jsVariables =
-      variables->Operation.serializeVariables->mapJsVariables;
+    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     let jsQueryTuple =
       Js_.useLazyQuery(.
@@ -157,14 +158,14 @@ let useLazyQueryWithVariables:
             ssr,
             variables: Some(jsVariables),
           },
-          ~parse=Operation.parse,
+          ~safeParse,
         ),
       );
 
     Utils.useGuaranteedMemo1(
       () => {
         jsQueryTuple->QueryTuple__noVariables.fromJs(
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
           // Passing in the same variables from above allows us to reuse some types
           ~variables=jsVariables,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
@@ -87,8 +87,10 @@ let useMutation:
             update,
             variables: None,
           },
+          ~mapJsVariables=Utils.identity,
           ~safeParse,
           ~serialize=Operation.serialize,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 
@@ -144,7 +146,6 @@ let useMutationWithVariables:
     ~update=?,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
     let safeParse = Utils.safeParse(Operation.parse);
 
     let jsMutationTuple =
@@ -165,10 +166,12 @@ let useMutationWithVariables:
             optimisticResponse,
             refetchQueries,
             update,
-            variables: Some(jsVariables),
+            variables: Some(variables),
           },
+          ~mapJsVariables,
           ~safeParse,
           ~serialize=Operation.serialize,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 
@@ -176,10 +179,12 @@ let useMutationWithVariables:
       () => {
         let (mutate, mutationResult) =
           jsMutationTuple->MutationTuple__noVariables.fromJs(
+            ~mapJsVariables,
             ~safeParse,
             ~serialize=Operation.serialize,
+            ~serializeVariables=Operation.serializeVariables,
             // Passing in the same variables from above allows us to reuse some types
-            ~variables=jsVariables,
+            ~variables,
           );
         (mutate, mutationResult);
       },

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.re
@@ -65,6 +65,8 @@ let useMutation:
     ~update=?,
     (),
   ) => {
+    let safeParse = Utils.safeParse(Operation.parse);
+
     let jsMutationTuple =
       Js_.useMutation(.
         Operation.query,
@@ -85,7 +87,7 @@ let useMutation:
             update,
             variables: None,
           },
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
         ),
       );
@@ -93,7 +95,7 @@ let useMutation:
     Utils.useGuaranteedMemo1(
       () => {
         jsMutationTuple->MutationTuple.fromJs(
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
           ~serializeVariables=Operation.serializeVariables,
         )
@@ -142,8 +144,8 @@ let useMutationWithVariables:
     ~update=?,
     variables,
   ) => {
-    let jsVariables =
-      variables->Operation.serializeVariables->mapJsVariables;
+    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     let jsMutationTuple =
       Js_.useMutation(.
@@ -165,7 +167,7 @@ let useMutationWithVariables:
             update,
             variables: Some(jsVariables),
           },
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
         ),
       );
@@ -174,7 +176,7 @@ let useMutationWithVariables:
       () => {
         let (mutate, mutationResult) =
           jsMutationTuple->MutationTuple__noVariables.fromJs(
-            ~parse=Operation.parse,
+            ~safeParse,
             ~serialize=Operation.serialize,
             // Passing in the same variables from above allows us to reuse some types
             ~variables=jsVariables,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -36,7 +36,7 @@ let useQuery:
       ~fetchPolicy: WatchQueryFetchPolicy.t=?,
       ~mapJsVariables: jsVariables => jsVariables=?,
       ~notifyOnNetworkStatusChange: bool=?,
-      ~onCompleted: data => unit=?,
+      ~onCompleted: Types.parseResult(data) => unit=?,
       ~onError: ApolloError.t => unit=?,
       ~partialRefetch: bool=?,
       ~pollInterval: int=?,
@@ -85,7 +85,7 @@ let useQuery:
             ssr,
             variables: jsVariables,
           },
-          ~parse=Operation.parse,
+          ~safeParse,
         ),
       );
 

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -62,8 +62,7 @@ let useQuery:
     ~ssr=?,
     variables,
   ) => {
-    let jsVariables =
-      variables->Operation.serializeVariables->mapJsVariables;
+    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
 
     let jsQueryResult =
       Js_.useQuery(.

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -44,7 +44,7 @@ let useQuery:
       ~ssr: bool=?,
       variables
     ) =>
-    QueryResult.t(data, jsData, jsVariables) =
+    QueryResult.t(data, jsData, variables, jsVariables) =
   (
     ~query as (module Operation),
     ~client=?,
@@ -62,7 +62,6 @@ let useQuery:
     ~ssr=?,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
     let safeParse = Utils.safeParse(Operation.parse);
 
     let jsQueryResult =
@@ -83,9 +82,11 @@ let useQuery:
             query: None,
             skip,
             ssr,
-            variables: jsVariables,
+            variables,
           },
+          ~mapJsVariables,
           ~safeParse,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 
@@ -94,6 +95,7 @@ let useQuery:
         jsQueryResult->QueryResult.fromJs(
           ~safeParse,
           ~serialize=Operation.serialize,
+          ~serializeVariables=Operation.serializeVariables,
         )
       },
       jsQueryResult,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.re
@@ -63,6 +63,7 @@ let useQuery:
     variables,
   ) => {
     let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     let jsQueryResult =
       Js_.useQuery(.
@@ -91,7 +92,7 @@ let useQuery:
     Utils.useGuaranteedMemo1(
       () => {
         jsQueryResult->QueryResult.fromJs(
-          ~parse=Operation.parse,
+          ~safeParse,
           ~serialize=Operation.serialize,
         )
       },

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
@@ -71,8 +71,8 @@ let useSubscription:
     ~skip=?,
     variables,
   ) => {
-    let jsVariables =
-      variables->Operation.serializeVariables->mapJsVariables;
+    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
+    let safeParse = Utils.safeParse(Operation.parse);
 
     let jsSubscriptionResult =
       Js_.useSubscription(.
@@ -88,7 +88,7 @@ let useSubscription:
             skip,
             variables: jsVariables,
           },
-          ~parse=Operation.parse,
+          ~safeParse,
         ),
       );
 

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.re
@@ -71,7 +71,6 @@ let useSubscription:
     ~skip=?,
     variables,
   ) => {
-    let jsVariables = variables->Operation.serializeVariables->mapJsVariables;
     let safeParse = Utils.safeParse(Operation.parse);
 
     let jsSubscriptionResult =
@@ -86,9 +85,11 @@ let useSubscription:
             subscription: None,
             shouldResubscribe,
             skip,
-            variables: jsVariables,
+            variables,
           },
+          ~mapJsVariables,
           ~safeParse,
+          ~serializeVariables=Operation.serializeVariables,
         ),
       );
 

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -327,7 +327,7 @@ module QueryResult = {
   type t('data, 'jsData, 'jsVariables) = {
     called: bool,
     client: ApolloClient.t,
-    data: option(Types.parseResult('data)),
+    data: option('data),
     error: option(ApolloError.t),
     loading: bool,
     networkStatus: NetworkStatus.t,
@@ -353,20 +353,28 @@ module QueryResult = {
     ) =>
     t('data, 'jsData, 'jsVariables) =
     (js, ~parse, ~serialize) => {
-      called: js.called,
-      client: js.client,
-      data: js.data->Belt.Option.map(Utils.safeParse(parse)),
-      error: js.error->Belt.Option.map(ApolloError.fromJs),
-      loading: js.loading,
-      networkStatus: js.networkStatus,
-      fetchMore: js.fetchMore,
-      refetch: js.refetch,
-      startPolling: js.startPolling,
-      stopPolling: js.stopPolling,
-      subscribeToMore: js.subscribeToMore,
-      updateQuery: js.updateQuery,
-      __parse: parse,
-      __serialize: serialize,
+      let (data, error) =
+        Utils.safeParseWithCommonProps(
+          ~jsData=js.data,
+          ~apolloError=?js.error->Belt.Option.map(ApolloError.fromJs),
+          parse,
+        );
+      {
+        called: js.called,
+        client: js.client,
+        data,
+        error,
+        loading: js.loading,
+        networkStatus: js.networkStatus,
+        fetchMore: js.fetchMore,
+        refetch: js.refetch,
+        startPolling: js.startPolling,
+        stopPolling: js.stopPolling,
+        subscribeToMore: js.subscribeToMore,
+        updateQuery: js.updateQuery,
+        __parse: parse,
+        __serialize: serialize,
+      };
     };
 
   let fetchMore:

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -480,19 +480,27 @@ module QueryResult = {
 
   let refetch:
     (t('data, 'jsData, 'jsVariables), 'jsVariables) =>
-    Js.Promise.t(ApolloQueryResult.t('data)) =
+    Promise.t(ApolloQueryResult.t('data)) =
     (queryResult, variables) =>
       queryResult
       ->unsafeCastForMethod
       ->Js_.refetch(variables)
-      ->Js.Promise.then_(
-          jsApolloQueryResult =>
-            Js.Promise.resolve(
-              jsApolloQueryResult->ApolloQueryResult.fromJs(
-                ~safeParse=queryResult.__safeParse,
+      ->Promise.Js.fromBsPromise
+      ->Promise.Js.toResult
+      ->Promise.map(result =>
+          switch (result) {
+          | Ok(jsApolloQueryResult) =>
+            jsApolloQueryResult->ApolloQueryResult.fromJs(
+              ~safeParse=queryResult.__safeParse,
+            )
+          | Error(error) =>
+            ApolloQueryResult.fromError(
+              ApolloError.make(
+                ~networkError=FetchFailure(Utils.ensureError(Any(error))),
+                (),
               ),
-            ),
-          _,
+            )
+          }
         );
 
   [@bs.send]
@@ -1003,7 +1011,7 @@ module MutationTuple = {
       ~update: MutationUpdaterFn.t('data)=?,
       'variables
     ) =>
-    Js.Promise.t(FetchResult.t('data));
+    Promise.t(FetchResult.t('data));
 
   type t('data, 'variables, 'jsVariables) = (
     t_mutationFn('data, 'variables, 'jsVariables),
@@ -1052,10 +1060,20 @@ module MutationTuple = {
             ),
           ),
         )
-        ->Js.Promise.then_(
-            jsResult =>
-              FetchResult.fromJs(jsResult, ~safeParse)->Js.Promise.resolve,
-            _,
+        ->Promise.Js.fromBsPromise
+        ->Promise.Js.toResult
+        ->Promise.map(result =>
+            switch (result) {
+            | Ok(jsFetchResult) =>
+              FetchResult.fromJs(jsFetchResult, ~safeParse)
+            | Error(error) =>
+              FetchResult.fromError(
+                ApolloError.make(
+                  ~networkError=FetchFailure(Utils.ensureError(Any(error))),
+                  (),
+                ),
+              )
+            }
           );
       };
 
@@ -1079,7 +1097,7 @@ module MutationTuple__noVariables = {
       ~fetchPolicy: WatchQueryFetchPolicy.t=?,
       unit
     ) =>
-    Js.Promise.t(FetchResult.t('data));
+    Promise.t(FetchResult.t('data));
 
   type t('data, 'jsVariables) = (
     t_mutationFn('data, 'jsVariables),
@@ -1122,10 +1140,20 @@ module MutationTuple__noVariables = {
             ),
           ),
         )
-        ->Js.Promise.then_(
-            jsResult =>
-              FetchResult.fromJs(jsResult, ~safeParse)->Js.Promise.resolve,
-            _,
+        ->Promise.Js.fromBsPromise
+        ->Promise.Js.toResult
+        ->Promise.map(result =>
+            switch (result) {
+            | Ok(jsFetchResult) =>
+              FetchResult.fromJs(jsFetchResult, ~safeParse)
+            | Error(error) =>
+              FetchResult.fromError(
+                ApolloError.make(
+                  ~networkError=FetchFailure(Utils.ensureError(Any(error))),
+                  (),
+                ),
+              )
+            }
           );
       };
 

--- a/src/ApolloClient__Types.re
+++ b/src/ApolloClient__Types.re
@@ -32,8 +32,13 @@ module type OperationNoRequiredVars = {
   let makeDefaultVariables: unit => t_variables;
 };
 
+type parseError = {
+  jsData: Js.Json.t,
+  error: Js.Exn.t,
+};
+
 type parseResult('data) =
   | Data('data)
-  | ParseError({data: Js.Json.t});
+  | ParseError(parseError);
 
-type safeParse('jsData, 'data) = 'jsData => parseResult('data);
+type safeParse('data, 'jsData) = 'jsData => parseResult('data);

--- a/src/ApolloClient__Types.re
+++ b/src/ApolloClient__Types.re
@@ -31,3 +31,9 @@ module type OperationNoRequiredVars = {
   include Operation;
   let makeDefaultVariables: unit => t_variables;
 };
+
+type parseResult('data) =
+  | Data('data)
+  | ParseError({data: Js.Json.t});
+
+type safeParse('jsData, 'data) = 'jsData => parseResult('data);

--- a/src/ApolloClient__Utils.re
+++ b/src/ApolloClient__Utils.re
@@ -4,6 +4,31 @@ module Types = ApolloClient__Types;
 
 [@bs.new] external makeError: string => Js.Exn.t = "Error";
 
+[@unboxed]
+type any =
+  | Any('a): any;
+
+let ensureError: any => Js.Exn.t = [%bs.raw
+  {|
+  function (unknown) {
+    if (unknown instanceof Error) {
+      return unknown;
+    } else {
+      unknown = unknown || {};
+      const message = unknown.message;
+      const errorMessage = unknown.errorMessage;
+      const error = new Error(message || errorMessage || "[no message]");
+
+      Object.keys(unknown).forEach(function(key) {
+        error[key] = JSON.stringify(unknown[key]);
+      });
+
+      return error
+    }
+  }
+  |}
+];
+
 external asJson: 'any => Js.Json.t = "%identity";
 
 let safeParse: ('jsData => 'data) => Types.safeParse('jsData, 'data) =

--- a/src/ApolloClient__Utils.re
+++ b/src/ApolloClient__Utils.re
@@ -1,4 +1,16 @@
 module Graphql = ApolloClient__Graphql;
+module Types = ApolloClient__Types;
+
+[@bs.new] external makeError: string => Js.Exn.t = "Error";
+
+external asJson: 'any => Js.Json.t = "%identity";
+
+let safeParse: ('jsData => 'data) => Types.safeParse('jsData, 'data) =
+  (parse, jsData) =>
+    switch (parse(jsData)) {
+    | data => Data(data)
+    | exception _ => ParseError({data: jsData->asJson})
+    };
 
 let useGuaranteedMemo1 = (f, dependency) => {
   let value = React.useRef(f());

--- a/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.re
+++ b/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.re
@@ -63,13 +63,13 @@ module ConnectionParamsOptions = {
   type t =
     | ConnectionParams(ConnectionParams.t)
     | Function(unit => ConnectionParams.t)
-    | Promise(Js.Promise.t(ConnectionParams.t));
+    | Promise(Promise.t(ConnectionParams.t));
 
   let toJs: t => Js_.t =
     fun
     | ConnectionParams(v) => Js_.Union.connectionParams(v)
     | Function(v) => Js_.Union.fn(v)
-    | Promise(v) => Js_.Union.promise(v);
+    | Promise(v) => Js_.Union.promise(v->Promise.Js.toBsPromise);
 };
 
 module ClientOptions = {


### PR DESCRIPTION
This PR attempts to resolve the outstanding configuration needs: #22. It was originally thought some sort of configuration module and functors would be necessary, but with a few smart choices I think we can avoid it. I went down that path for a bit and we’d definitely like to avoid it!

As it currently stands, this experiment only covers `query` and `useQuery` and there are still some things I would like to change or clean up about the current implementation. That said, I'd like to get feedback on the approach before going much further.

## Goals

### Provide sane promise defaults

We use records a lot, so using a T-first promise library for better type inference would be very helpful. There should also be a way to opt out or provide their own promise transformation function. Here I've chosen to use `reason-promise`, but how do we deal with the promise opt-out/configuration problem? Well, I don’t think we have to. Ultimately, a `Promise.t` is just a `Js.Promise.t` under the hood that won’t reject. If you want to use your own promise, we’ll expose zero-cost conversion functions from `Promise.t => Js.Promise.t` and vice versa. You’re in no worse situation than you would be if we decided to stick with `Js.Promise.t`, IMO.

### Don’t allow parse exceptions to escape the library

These should never happen if everything is working properly, but there are a bunch of reasons why things might not be working properly :) Ideally this change would be transparent to the developer experience (you just always have optional data) and as such there's no need for any kind of configuration. And we _definitely_ don’t want hide a parse failure as `None`. Here I've wrapped parse to return a result rather than throwing an exception. We'll get to how we make the change transparent next.

### Combine separate failures into one type that can encapsulate any type of failure
So Apollo already provides several types of "results" that allow you to express some sort of success (data) or failure (error or errors). In these cases I don't see why we should be dealing with other types of results. In the case of a promise, it's very easy to fall into this sort of trap:
```
apolloClient
->ApolloClient.mutation(~mutation=(module AddTodo), ())
->Promise.get(
    fun
    | Ok(_) => Js.log("We're good!") // You forgot to check for errors!
    | Error(_) => Js.log("Something went wrong!"),
  );
```

We also want to account for parse failures. Both of these failures fall outside of whatever Apollo "result" we're dealing with so in order to account for them we'll need diverge a bit from the official Apollo types. Now any Apollo "result" that contains `errors: array(GraphQLError.t)` will be lifted to contain an `error: ApolloError.t` so we can represent all types of failures.

Promise errors become an `ApolloError.t` with `networkError: Some(FetchFailure(...))` on the Apollo "result". What used to be `Js.Promise.t(somekindOfApolloResult)` that could reject is converted to `Promise.t(someKindOfApolloResultWithApolloError)`. Notice there is no `Belt.Result.t` in there because we’ve already combined the rejection into this new result. You can only ever resolve with an Apollo result, never reject.

Parse failures get unwrapped before exposing to the user by converting data to `None` and error to be an `ApolloError.t` with `networkError: Some(ParseError(...))`.


### Define a type for context so it’s consistent across all operations
I'm explicitly giving up on this one. I don’t feel like it’s worth the effort and I kinda don’t trust that we can ensure context is always what we say it is anyway. I think leaving it up to the user to create a module to parse/serialize context is not a big deal. We could further enforce the conversion with an abstract type vs. Js.Json.t, but I’m not sure that’s worth explaining to new users either. So I’m abandoning the goal, at least for now.