### PR TITLE
Experiment with safe methods on records

### DIFF
--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -24,7 +24,7 @@
     "graphql": "^14.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "reason-apollo-client": "0.0.1-beta.7",
+    "reason-apollo-client": "../",
     "reason-promise": "1.1.1",
     "reason-react": "0.9.1",
     "subscriptions-transport-ws": "0.9.16"

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -25,8 +25,7 @@ module TodosQuery = [%graphql
 ];
 
 let logTodos = _ =>
-  Client.instance
-  ->ApolloClient.query(~query=(module TodosQuery), ())
+  Client.instance.query(~query=(module TodosQuery), ())
   ->Promise.get(
       fun
       | {data: Some({todos}), error: None} =>
@@ -35,11 +34,10 @@ let logTodos = _ =>
     );
 
 let addTodo = _ =>
-  Client.instance
-  ->ApolloClient.mutate(
-      ~mutation=(module AddTodoMutation),
-      {text: "Another To-Do"},
-    )
+  Client.instance.mutate(
+    ~mutation=(module AddTodoMutation),
+    {text: "Another To-Do"},
+  )
   ->Promise.get(
       fun
       | {data: Some(data), error: None} => Js.log2("mutate result: ", data)
@@ -47,7 +45,7 @@ let addTodo = _ =>
     );
 
 let observableQuery =
-  Client.instance->ApolloClient.watchQuery(~query=(module TodosQuery), ());
+  Client.instance.watchQuery(~query=(module TodosQuery), ());
 
 let watchQuerySubscription =
   observableQuery.subscribe(
@@ -60,7 +58,7 @@ let watchQuerySubscription =
     (),
   );
 // Unsubscribe like so:
-watchQuerySubscription.unsubscribe();
+// watchQuerySubscription.unsubscribe();
 
 [@react.component]
 let make = () => {

--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -101,7 +101,7 @@ let watchQuerySubscription =
       (),
     );
 // Unsubscribe like so:
-// watchQuerySubscription->ApolloClient.ObservableQuery.Subscription.unsubscribe;
+watchQuerySubscription.unsubscribe();
 
 [@react.component]
 let make = () => {

--- a/EXAMPLES/src/hooksUsage/Mutation.re
+++ b/EXAMPLES/src/hooksUsage/Mutation.re
@@ -50,7 +50,7 @@ let make = () => {
                   },
                 },
             ~update=
-              (cache, {data}) =>
+              ({writeFragment, writeQuery}, {data}) =>
                 switch (data) {
                 | Some({todo}) =>
                   /**
@@ -59,7 +59,7 @@ let make = () => {
                    */
                   Js.log2("mutate.update To-Do: ", todo);
                   let _unusedRef =
-                    cache->Cache.writeFragment(
+                    writeFragment(
                       ~fragment=(module Fragments.TodoItem),
                       ~data={
                         __typename: todo.__typename,
@@ -70,7 +70,7 @@ let make = () => {
                       (),
                     );
                   let _unusedRef =
-                    cache->Cache.writeQuery(
+                    writeQuery(
                       ~query=(module TodosQuery),
                       ~data={
                         todos: [|

--- a/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
+++ b/EXAMPLES/src/hooksUsage/Query_SubscribeToMore.re
@@ -30,7 +30,7 @@ let make = () => {
    * Sorry, this example is nonsensical given the current schema, but I'm gonna proceed anyway
    */
   React.useEffect0(() => {
-    queryResult->QueryResult.subscribeToMore(
+    queryResult.subscribeToMore(
       ~subscription=(module SorryItsNotASubscriptionForTodos),
       ~updateQuery=
         (previous, {subscriptionData: {data: {siteStatisticsUpdated}}}) => {

--- a/EXAMPLES/src/hooksUsage/Query_Typical.re
+++ b/EXAMPLES/src/hooksUsage/Query_Typical.re
@@ -19,7 +19,7 @@ let make = () => {
   <div>
     {switch (queryResult) {
      | {loading: true, data: None} => <p> "Loading"->React.string </p>
-     | {loading, data: Some({todos}), error} =>
+     | {loading, data: Some({todos}), error, fetchMore} =>
        <>
          <dialog>
            {loading ? <p> "Refreshing..."->React.string </p> : React.null}
@@ -41,20 +41,19 @@ let make = () => {
          <p>
            <button
              onClick={_ =>
-               queryResult
-               ->QueryResult.fetchMore(
-                   ~updateQuery=
-                     (previousData, {fetchMoreResult}) => {
-                       switch (fetchMoreResult) {
-                       | Some({todos: newTodos}) => {
-                           todos:
-                             Belt.Array.concat(previousData.todos, newTodos),
-                         }
-                       | None => previousData
+               fetchMore(
+                 ~updateQuery=
+                   (previousData, {fetchMoreResult}) => {
+                     switch (fetchMoreResult) {
+                     | Some({todos: newTodos}) => {
+                         todos:
+                           Belt.Array.concat(previousData.todos, newTodos),
                        }
-                     },
-                   (),
-                 )
+                     | None => previousData
+                     }
+                   },
+                 (),
+               )
                ->Promise.get(({error}) =>
                    if (error->Belt.Option.isSome) {
                      Js.log2("Failed to fetch more: ", error);

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.re
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.re
@@ -71,7 +71,7 @@ module Js_ = {
   external make: InMemoryCacheConfig.Js_.t => t = "InMemoryCache";
 };
 
-type t = Js_.t;
+type t = ApolloCache.t(Js.Json.t);
 
 let make:
   (
@@ -100,5 +100,6 @@ let make:
         ~typePolicies=?typePolicies->Belt.Option.map(TypePolicies.toJs),
         (),
       ),
-    );
+    )
+    ->ApolloCache.fromJs;
   };

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.re
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.re
@@ -123,7 +123,9 @@ module TypePolicy = {
                   | FieldPolicy(fieldPolicy) =>
                     fieldPolicy->FieldPolicy.toJs->Js_.FieldsUnion.fieldPolicy
                   | FieldReadFunction(fieldReadFunction) =>
-                    fieldReadFunction->Js_.FieldsUnion.fieldReadFunction
+                    fieldReadFunction
+                    ->FieldReadFunction.toJs
+                    ->Js_.FieldsUnion.fieldReadFunction
                   },
                 )
               })

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
@@ -115,11 +115,14 @@ module ObservableQuery = {
        * Ugh, this diverges from normal patterns because data in these callbacks has to be parsed before this point.
        * I wonder if there is a way we could pass parse along and then use it here or maybe there is a better pattern for this.
        */
-      Js_.subscribe(
-        t->castToJs,
-        ~onNext=Obj.magic(onNext),
-        ~onError?,
-        ~onComplete?,
-        (),
+      (
+        Js_.subscribe(
+          t->castToJs,
+          ~onNext=Obj.magic(onNext),
+          ~onError?,
+          ~onComplete?,
+          (),
+        )
+        ->Subscription.fromJs
       );
 };

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
@@ -52,7 +52,7 @@ module ObservableQuery = {
     // ...extends Observable<ApolloQueryResult<TData>>
     // <R>(callback: (value: T) => R): Observable<R>;
     [@bs.send] external map: (t('t), 't => 'r) => t('r) = "map";
-    let fakeMap: (t('t), 't => 'r) => t('r) =
+    let fakeMap: (t('t), ('t, Js.Exn.t => unit) => option('r)) => t('r) =
       (js, fn) =>
         /**
           * We should be able to just map, but it's broken:
@@ -67,8 +67,9 @@ module ObservableQuery = {
               var originalSubscribe = js.subscribe.bind(js);
               js.subscribe = function (onNext, onError, onComplete) {
                 var newOnNext = function (result) {
-                  var transformedResult = result.data
-                    ? Object.assign({}, result, { data: fn(result.data) })
+                  var parsedData = result.data ? fn(result.data, onError) : undefined;
+                  var transformedResult = parsedData
+                    ? Object.assign({}, result, { data: parsedData })
                     : result;
                   return onNext(transformedResult);
                 };
@@ -99,7 +100,7 @@ module ObservableQuery = {
   };
 
   type t('data) = {
-    map: 'mappedData. ('data => 'mappedData) => t('mappedData),
+    [@bs.as "reason_subscribe"]
     subscribe:
       (
         ~onNext: ApolloQueryResult.t('data) => unit,
@@ -114,38 +115,52 @@ module ObservableQuery = {
 
   external castToJs: t('data) => Js_.t('data) = "%identity";
 
+  let preserveJsPropsAndContext: (Js_.t('jsData), t('data)) => t('data) =
+    (js, t) =>
+      [%bs.raw
+        {|
+          function (js, t) {
+            return Object.assign(js, t)
+          }
+        |}
+      ](
+        js,
+        t,
+      );
+
   let fromJs:
     (Js_.t('jsData), ~safeParse: Types.safeParse('data, 'jsData)) =>
     t('data) =
     (js, ~safeParse) => {
-      let observableWithParsedData =
-        js->Js_.fakeMap(jsData =>
-          switch (safeParse(jsData)) {
-          | Data(data) => data
-          | ParseError(_error) =>
-            Js.Exn.raiseError(
-              "OMG, Becky. There was a parse error in an observable",
-            )
-          }
-        );
-      {
-        map: f => {
-          observableWithParsedData->Js_.fakeMap(f)->castFromJs;
-        },
+      let parseWithOnErrorCall = (jsData, onError) =>
+        switch (safeParse(jsData)) {
+        | Data(data) => Some(data)
+        | ParseError({error}) =>
+          onError(error);
+          None;
+        };
 
-        subscribe: (~onNext, ~onError=?, ~onComplete=?, ()) =>
-          js
-          ->Js_.subscribe(
-              ~onNext=
-                jsApolloQueryResult =>
-                  onNext(
-                    jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse),
-                  ),
-              ~onError?,
-              ~onComplete?,
-              (),
-            )
-          ->Subscription.fromJs,
-      };
+      let observableWithParsedData = js->Js_.fakeMap(parseWithOnErrorCall);
+
+      preserveJsPropsAndContext(
+        observableWithParsedData,
+        {
+          subscribe: (~onNext, ~onError=?, ~onComplete=?, ()) =>
+            js
+            ->Js_.subscribe(
+                ~onNext=
+                  jsApolloQueryResult =>
+                    onNext(
+                      jsApolloQueryResult->ApolloQueryResult.fromJs(
+                        ~safeParse,
+                      ),
+                    ),
+                ~onError?,
+                ~onComplete?,
+                (),
+              )
+            ->Subscription.fromJs,
+        },
+      );
     };
 };

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
@@ -291,7 +291,7 @@ module SubscribeToMoreOptions = {
 module MutationUpdaterFn = {
   module Js_ = {
     type t('jsData) =
-      (. ApolloCache.Js_.t(Js.Json.t), FetchResult.Js_.t('jsData)) => unit;
+      (. ApolloCache.t(Js.Json.t), FetchResult.Js_.t('jsData)) => unit; // Non-Js_ cache is correct here
   };
 
   type t('data) = (ApolloCache.t(Js.Json.t), FetchResult.t('data)) => unit;
@@ -309,7 +309,6 @@ module MutationUpdaterFn = {
 
 module RefetchQueryDescription = {
   module Js_ = {
-    // CAVEAT: I did not try very hard to find a simpler alternative
     module Union: {
       type t;
       let string: string => t;

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_ApolloLink.re
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_ApolloLink.re
@@ -70,4 +70,10 @@ let from = Js_.from;
 
 let setOnError = Js_.setOnError;
 
-let split: (t, ~test: Operation.t => bool, ~whenTrue: t, ~whenFalse: t) => t = Js_.split;
+let split: (t, ~test: Operation.t => bool, ~whenTrue: t, ~whenFalse: t) => t =
+  (t, ~test, ~whenTrue, ~whenFalse) =>
+    t->Js_.split(
+      ~test=jsOperation => test(jsOperation->Operation.fromJs),
+      ~whenTrue,
+      ~whenFalse,
+    );

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
@@ -42,24 +42,31 @@ module Operation = {
       variables: Js.Json.t,
       operationName: string,
       extensions: Js.Json.t,
-      setContext: useMethodFunctionInThisModuleInstead,
-      getContext: useMethodFunctionInThisModuleInstead,
     };
+
+    [@bs.send] external getContext: t => Js.Json.t = "getContext";
+
+    [@bs.send] external setContext: (t, Js.Json.t) => Js.Json.t = "setContext";
   };
 
-  type t =
-    Js_.t = {
-      query: Graphql.documentNode,
-      variables: Js.Json.t,
-      operationName: string,
-      extensions: Js.Json.t,
-      setContext: useMethodFunctionInThisModuleInstead,
-      getContext: useMethodFunctionInThisModuleInstead,
+  type t = {
+    query: Graphql.documentNode,
+    variables: Js.Json.t,
+    operationName: string,
+    extensions: Js.Json.t,
+    setContext: Js.Json.t => Js.Json.t,
+    getContext: unit => Js.Json.t,
+  };
+
+  let fromJs: Js_.t => t =
+    js => {
+      query: js.query,
+      variables: js.variables,
+      operationName: js.operationName,
+      extensions: js.extensions,
+      setContext: context => js->Js_.setContext(context),
+      getContext: () => js->Js_.getContext,
     };
-
-  [@bs.send] external getContext: t => Js.Json.t = "getContext";
-
-  [@bs.send] external setContext: (t, Js.Json.t) => Js.Json.t = "setContext";
 };
 
 module FetchResult = {

--- a/src/@apollo/client/link/error/ApolloClient__Link_Error.re
+++ b/src/@apollo/client/link/error/ApolloClient__Link_Error.re
@@ -98,7 +98,7 @@ module ErrorResponse = {
             }
           ),
       response: js.response,
-      operation: js.operation,
+      operation: js.operation->Operation.fromJs,
       forward: js.forward,
     };
 };

--- a/src/@apollo/client/link/ws/ApolloClient__Link_Ws.re
+++ b/src/@apollo/client/link/ws/ApolloClient__Link_Ws.re
@@ -36,8 +36,8 @@ module WebSocketLink = {
       (
       [@bs.unwrap]
       [
-        | `Configuration(Configuration.Js_.t)
-        | `SubscriptionClient(SubscriptionClient.Js_.t)
+        | `Configuration(Configuration.Js_.t) // Non-Js_ SubscriptionClient is correct here
+        | `SubscriptionClient(SubscriptionClient.t) // Non-Js_ SubscriptionClient is correct here
       ]
       ) =>
       ApolloLink.Js_.t =

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -253,7 +253,7 @@ module QueryResult = {
       data: option('jsData),
       error: option(ApolloError.Js_.t),
       loading: bool,
-      networkStatus: NetworkStatus.t,
+      networkStatus: NetworkStatus.Js_.t,
       // ...extends ObservableQueryFields<TData, TVariables> = Pick<ObservableQuery<TData, TVariables>, 'startPolling' | 'stopPolling' | 'subscribeToMore' | 'updateQuery' | 'refetch' | 'jsVariables'>
       fetchMore: useMethodFunctionsInThisModuleInstead,
       refetch: useMethodFunctionsInThisModuleInstead,
@@ -442,7 +442,7 @@ module QueryResult = {
         data,
         error,
         loading: js.loading,
-        networkStatus: js.networkStatus,
+        networkStatus: js.networkStatus->NetworkStatus.fromJs,
         fetchMore: js.fetchMore,
         refetch: js.refetch,
         startPolling: js.startPolling,

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -392,9 +392,6 @@ module QueryResult = {
         'data
       ) =>
       unit,
-    __safeParse: Types.safeParse('data, 'jsData),
-    __serialize: 'data => 'jsData,
-    __serializeVariables: 'variables => 'jsVariables,
   };
 
   external unsafeCastForMethod:
@@ -588,12 +585,8 @@ module QueryResult = {
         stopPolling,
         subscribeToMore,
         updateQuery,
-        __safeParse: safeParse,
-        __serialize: serialize,
-        __serializeVariables: serializeVariables,
       };
     };
-
 };
 
 module UnexecutedLazyResult = {

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -334,7 +334,7 @@ module QueryResult = {
       ),
   };
 
-  type subscribeToMore_error =
+  type t_subscribeToMoreError =
     | ParseError(Types.parseError)
     | SubscriptionError(Js.Exn.t);
 
@@ -380,7 +380,7 @@ module QueryResult = {
                         'subscriptionData,
                       )
                         =?,
-        ~onError: subscribeToMore_error => unit=?,
+        ~onError: t_subscribeToMoreError => unit=?,
         ~context: Js.Json.t=?,
         'subscriptionVariables
       ) =>
@@ -829,7 +829,7 @@ module MutationHookOptions = {
       [@bs.optional]
       awaitRefetchQueries: bool,
       [@bs.optional]
-      client: ApolloClient.Js_.t,
+      client: ApolloClient.t, // Non-Js_ client is appropriate here
       [@bs.optional]
       context: Js.Json.t, // actual: option(Context)
       [@bs.optional]
@@ -928,7 +928,7 @@ module MutationResult = {
       error: option(ApolloError.Js_.t),
       loading: bool,
       called: bool,
-      client: option(ApolloClient.Js_.t),
+      client: option(ApolloClient.t) // Non-Js_ client is appropriate here
     };
   };
 

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -275,7 +275,7 @@ module QueryResult = {
 
     [@bs.send]
     external refetch:
-      (t('jsData, 'jsVariables), 'jsVariables) =>
+      (t('jsData, 'jsVariables), option('jsVariables)) =>
       Js.Promise.t(ApolloQueryResult.Js_.t('jsData)) =
       "refetch";
 
@@ -364,7 +364,11 @@ module QueryResult = {
       ) =>
       Promise.t(ApolloQueryResult.t('data)),
     refetch:
-      (~mapJsVariables: 'jsVariables => 'jsVariables=?, 'variables) =>
+      (
+        ~mapJsVariables: 'jsVariables => 'jsVariables=?,
+        ~variables: 'variables=?,
+        unit
+      ) =>
       Promise.t(ApolloQueryResult.t('data)),
     startPolling: int => unit,
     stopPolling: unit => unit,
@@ -501,9 +505,13 @@ module QueryResult = {
           });
       };
 
-      let refetch = (~mapJsVariables=Utils.identity, variables) => {
+      let refetch = (~mapJsVariables=Utils.identity, ~variables=?, ()) => {
         js
-        ->Js_.refetch(variables->serializeVariables->mapJsVariables)
+        ->Js_.refetch(
+            variables->Belt.Option.map(v =>
+              v->serializeVariables->mapJsVariables
+            ),
+          )
         ->Promise.Js.fromBsPromise
         ->Promise.Js.toResult
         ->Promise.map(result =>

--- a/src/ReasonMLCommunity__ApolloClient.re
+++ b/src/ReasonMLCommunity__ApolloClient.re
@@ -1,7 +1,6 @@
 [@text {|{1 Creating a client}|}];
 type t = ApolloClient__ApolloClient.t;
 let make = ApolloClient__ApolloClient.make;
-let setLink = ApolloClient__ApolloClient.setLink;
 
 module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions;
 module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions;
@@ -9,13 +8,6 @@ module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions;
 module DefaultOptions = ApolloClient__ApolloClient.DefaultOptions;
 
 [@text {|{1 Fetching data }|}];
-let mutate = ApolloClient__ApolloClient.mutate;
-let query = ApolloClient__ApolloClient.query;
-let readQuery = ApolloClient__ApolloClient.readQuery;
-let watchQuery = ApolloClient__ApolloClient.watchQuery;
-let writeFragment = ApolloClient__ApolloClient.writeFragment;
-let writeQuery = ApolloClient__ApolloClient.writeQuery;
-
 module React = {
   module ApolloProvider = ApolloClient__React_Context_ApolloProvider;
   let useApolloClient = ApolloClient__React_Hooks_UseApolloClient.useApolloClient;
@@ -33,10 +25,6 @@ module Cache = {
     ApolloClient__Cache_Core_Cache.ApolloCache.t('serialized);
   // Creating
   module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache;
-  // Reading and writing
-  let readQuery = ApolloClient__Cache_Core_Cache.ApolloCache.readQuery;
-  let writeFragment = ApolloClient__Cache_Core_Cache.ApolloCache.writeFragment;
-  let writeQuery = ApolloClient__Cache_Core_Cache.ApolloCache.writeQuery;
   // Local state management
   let makeVar = ApolloClient__Cache_InMemory_ReactiveVars.makeVar;
 };

--- a/src/zen-observable/ApolloClient__ZenObservable.re
+++ b/src/zen-observable/ApolloClient__ZenObservable.re
@@ -18,17 +18,18 @@ module Subscription = {
     //     closed: boolean;
     //     unsubscribe(): void;
     // }
-    type t = {
-      closed: bool
-    };
+    type t = {closed: bool};
 
-    [@bs.send]
-    external unsubscribe: (t) => unit ="unsubscribe";
+    [@bs.send] external unsubscribe: t => unit = "unsubscribe";
   };
 
-  type t = Js_.t;
+  type t = {
+    closed: bool,
+    unsubscribe: unit => unit,
+  };
 
-  let unsubscribe = Js_.unsubscribe;
+  let fromJs: Js_.t => t =
+    js => {closed: js.closed, unsubscribe: () => js->Js_.unsubscribe};
 };
 
 module Observer = {


### PR DESCRIPTION
So I think I was thinking about this all wrong. It's only unsafe to write _bindings_ to an object method when using records. So we need to use `bs.send` for the `Js_` bindings, but after that we have no such limitations. Here, the function on the reason record has a closure to the original `Js_` object and the method is called using a `bs.send` binding. With this pattern, I think we can move to a much better api where you can destructure methods like `fetchMore` directly on the query result, etc.

In the changes, you can see the unsubscribe method that used to fail when the Js bindings were written directly as a record, but this works perfectly fine.