### PR TITLE
Results Inception

### DIFF
--- a/EXAMPLES/src/clientUsage/ClientBasics.re
+++ b/EXAMPLES/src/clientUsage/ClientBasics.re
@@ -28,9 +28,8 @@ let logTodos = _ =>
   Client.instance.query(~query=(module TodosQuery), ())
   ->Promise.get(
       fun
-      | {data: Some({todos}), error: None} =>
-        Js.log2("query To-Dos: ", todos)
-      | {error} => Js.log2("Error: ", error),
+      | Ok({data: {todos}}) => Js.log2("query To-Dos: ", todos)
+      | Error(error) => Js.log2("Error: ", error),
     );
 
 let addTodo = _ =>
@@ -40,8 +39,8 @@ let addTodo = _ =>
   )
   ->Promise.get(
       fun
-      | {data: Some(data), error: None} => Js.log2("mutate result: ", data)
-      | {error} => Js.log2("Error: ", error),
+      | Ok({data}) => Js.log2("mutate result: ", data)
+      | Error(error) => Js.log2("Error: ", error),
     );
 
 let observableQuery =

--- a/EXAMPLES/src/clientUsage/ClientMethodChaining.re
+++ b/EXAMPLES/src/clientUsage/ClientMethodChaining.re
@@ -1,0 +1,79 @@
+module ApolloQueryResult = ApolloClient.Types.ApolloQueryResult;
+module FetchResult = ApolloClient.Types.FetchResult;
+
+module AddTodoMutation = [%graphql
+  {|
+    mutation AddTodo($text: String!) {
+      todo: addTodoSimple(text: $text) {
+        id
+        text
+      }
+    }
+  |}
+];
+
+module TodosQuery = [%graphql
+  {|
+    query TodosQuery {
+      todos: allTodos {
+        id
+        text
+        completed
+      }
+    }
+  |}
+];
+let fauxTodosQuery = ();
+let fauxAddTodoMutation = ();
+
+type fauxVariables = {text: string};
+type fauxJsClient('query, 'mutation) = {
+  query:
+    (~query: 'query, unit) =>
+    Js.Promise.t(ApolloClient.Types.ApolloQueryResult.t(Js.Json.t)),
+  mutate:
+    (~mutation: 'mutation, fauxVariables) =>
+    Js.Promise.t(ApolloClient.Types.FetchResult.t(Js.Json.t)),
+};
+
+let client = Client.instance;
+[@bs.val] external jsClient: fauxJsClient('query, 'mutation) = "jsClient";
+
+client.query(~query=(module TodosQuery), ())
+->Promise.flatMapOk(({data}) => {
+    client.mutate(~mutation=(module AddTodoMutation), {text: ""})
+  })
+->Promise.get(result =>
+    switch (result) {
+    | Ok(_) => Js.log("Success for both!")
+    | Error(error) =>
+      Js.log2("Typed ApolloError if one of them failed!", error)
+    }
+  );
+
+jsClient.query(~query=fauxTodosQuery, ())
+|> Js.Promise.then_((apolloQueryResult: ApolloQueryResult.t(_)) => {
+     switch (apolloQueryResult) {
+     | {data: Some(data), error: None} =>
+       jsClient.mutate(~mutation=fauxAddTodoMutation, {text: ""})
+       |> Js.Promise.then_((fetchResult: FetchResult.t(_)) => {
+            switch (fetchResult) {
+            | {data: Some(data), error: None} => Js.Promise.resolve(data)
+            | {error: Some(error)} => Js.Promise.reject(Obj.magic(error))
+            | {data: None, error: None} =>
+              Js.Promise.reject(Obj.magic(":_("))
+            }
+          })
+     | {error: Some(error)} => Js.Promise.reject(Obj.magic(error))
+     | {data: None, error: None} =>
+       Js.Promise.reject(
+         Obj.magic(
+           "As a new user how do I create an exn? Should I raise instead?",
+         ),
+       )
+     }
+   })
+|> Js.Promise.then_(_ => Js.Promise.resolve(Js.log("Success for both!")))
+|> Js.Promise.catch(error =>
+     Js.Promise.resolve(Js.log2("Untyped error of something!", error))
+   );

--- a/EXAMPLES/src/hooksUsage/Query_Typical.re
+++ b/EXAMPLES/src/hooksUsage/Query_Typical.re
@@ -54,10 +54,8 @@ let make = () => {
                    },
                  (),
                )
-               ->Promise.get(({error}) =>
-                   if (error->Belt.Option.isSome) {
-                     Js.log2("Failed to fetch more: ", error);
-                   }
+               ->Promise.getError(error =>
+                   Js.log2("Failed to fetch more: ", error)
                  )
              }>
              "Fetch More!"->React.string

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -394,6 +394,7 @@ module Js_ = {
 };
 
 type t = {
+  [@bs.as "reason_clearStore"]
   clearStore: unit => Promise.t(Belt.Result.t(array(Js.Json.t), Js.Exn.t)),
   [@bs.as "reason_mutate"]
   mutate:

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -414,7 +414,7 @@ type t = {
       ~update: MutationUpdaterFn.t('data)=?,
       'variables
     ) =>
-    Promise.t(FetchResult.t('data)),
+    Promise.t(Belt.Result.t(FetchResult.t__ok('data), ApolloError.t)),
 
   [@bs.as "reason_onClearStore"]
   onClearStore: (~cb: unit => Promise.t(unit), unit) => unit,
@@ -435,7 +435,7 @@ type t = {
       ~mapJsVariables: 'jsVariables => 'jsVariables=?,
       'variables
     ) =>
-    Promise.t(ApolloQueryResult.t('data)),
+    Promise.t(Belt.Result.t(ApolloQueryResult.t__ok('data), ApolloError.t)),
 
   [@bs.as "reason_readQuery"]
   readQuery:
@@ -649,7 +649,8 @@ let make:
               ),
             )
           }
-        });
+        })
+      ->Promise.map(FetchResult.toResult);
     };
 
     let onClearStore = (~cb) =>
@@ -706,7 +707,8 @@ let make:
               ),
             )
           }
-        });
+        })
+      ->Promise.map(ApolloQueryResult.toResult);
     };
 
     let readQuery =

--- a/src/@apollo/client/core/ApolloClient__Core_Types.re
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.re
@@ -94,6 +94,35 @@ module ApolloQueryResult = {
       loading: false,
       networkStatus: Error,
     };
+
+  type t__ok('data) = {
+    data: 'data,
+    error: option(ApolloError.t),
+    loading: bool,
+    networkStatus: NetworkStatus.t,
+  };
+
+  let toResult: t('data) => Belt.Result.t(t__ok('data), ApolloError.t) =
+    apolloQueryResult => {
+      switch (apolloQueryResult) {
+      | {data: Some(data)} =>
+        Ok({
+          data,
+          error: apolloQueryResult.error,
+          loading: apolloQueryResult.loading,
+          networkStatus: apolloQueryResult.networkStatus,
+        })
+      | {error: Some(error)} => Error(error)
+      | {data: None, error: None} =>
+        Error(
+          ApolloError.make(
+            ~errorMessage=
+              "No data and no error on ApolloQueryResult.t. Shouldn't this be impossible?",
+            (),
+          ),
+        )
+      };
+    };
 };
 
 module MutationQueryReducer = {

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.re
@@ -28,6 +28,7 @@ module GraphQLRequest = {
 
 module Operation = {
   type useMethodFunctionInThisModuleInstead;
+
   module Js_ = {
     // export interface Operation {
     //     query: DocumentNode;
@@ -130,6 +131,35 @@ module FetchResult = {
       extensions: None,
       context: None,
       error: Some(error),
+    };
+
+  type t__ok('data) = {
+    data: 'data,
+    error: option(ApolloError.t),
+    extensions: option(Js.Json.t),
+    context: option(Js.Json.t),
+  };
+
+  let toResult: t('data) => Belt.Result.t(t__ok('data), ApolloError.t) =
+    fetchResult => {
+      switch (fetchResult) {
+      | {data: Some(data)} =>
+        Ok({
+          data,
+          error: fetchResult.error,
+          extensions: fetchResult.extensions,
+          context: fetchResult.context,
+        })
+      | {error: Some(error)} => Error(error)
+      | {data: None, error: None} =>
+        Error(
+          ApolloError.make(
+            ~errorMessage=
+              "No data and no error on FetchResult.t. Shouldn't this be impossible?",
+            (),
+          ),
+        )
+      };
     };
 };
 

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -362,14 +362,18 @@ module QueryResult = {
                         =?,
         unit
       ) =>
-      Promise.t(ApolloQueryResult.t('data)),
+      Promise.t(
+        Belt.Result.t(ApolloQueryResult.t__ok('data), ApolloError.t),
+      ),
     refetch:
       (
         ~mapJsVariables: 'jsVariables => 'jsVariables=?,
         ~variables: 'variables=?,
         unit
       ) =>
-      Promise.t(ApolloQueryResult.t('data)),
+      Promise.t(
+        Belt.Result.t(ApolloQueryResult.t__ok('data), ApolloError.t),
+      ),
     startPolling: int => unit,
     stopPolling: unit => unit,
     subscribeToMore:
@@ -502,7 +506,8 @@ module QueryResult = {
                 ),
               )
             }
-          });
+          })
+        ->Promise.map(ApolloQueryResult.toResult);
       };
 
       let refetch = (~mapJsVariables=Utils.identity, ~variables=?, ()) => {
@@ -526,7 +531,8 @@ module QueryResult = {
                 ),
               )
             }
-          );
+          )
+        ->Promise.map(ApolloQueryResult.toResult);
       };
 
       let startPolling = pollInterval => js->Js_.startPolling(pollInterval);
@@ -1051,7 +1057,7 @@ module MutationTuple = {
       ~update: MutationUpdaterFn.t('data)=?,
       'variables
     ) =>
-    Promise.t(FetchResult.t('data));
+    Promise.t(Belt.Result.t(FetchResult.t__ok('data), ApolloError.t));
 
   type t('data, 'variables, 'jsVariables) = (
     t_mutationFn('data, 'variables, 'jsVariables),
@@ -1116,7 +1122,8 @@ module MutationTuple = {
                 ),
               )
             }
-          );
+          )
+        ->Promise.map(FetchResult.toResult);
       };
 
       (mutationFn, jsMutationResult->MutationResult.fromJs(~safeParse));
@@ -1139,7 +1146,7 @@ module MutationTuple__noVariables = {
       ~fetchPolicy: WatchQueryFetchPolicy.t=?,
       unit
     ) =>
-    Promise.t(FetchResult.t('data));
+    Promise.t(Belt.Result.t(FetchResult.t__ok('data), ApolloError.t));
 
   type t('data, 'jsVariables) = (
     t_mutationFn('data, 'jsVariables),
@@ -1207,7 +1214,8 @@ module MutationTuple__noVariables = {
                 ),
               )
             }
-          );
+          )
+        ->Promise.map(FetchResult.toResult);
       };
 
       (mutationFn, jsMutationResult->MutationResult.fromJs(~safeParse));

--- a/src/ApolloClient__Promise.re
+++ b/src/ApolloClient__Promise.re
@@ -1,0 +1,22 @@
+type t('a) = Promise.t('a);
+
+let fromJs = Promise.Js.fromBsPromise;
+
+let toJs = Promise.Js.toBsPromise;
+
+let resultToJs = promise =>
+  promise->Promise.Js.fromResult->Promise.Js.toBsPromise;
+
+module Js = {
+  let resolve = Js.Promise.resolve;
+  let reject = Js.Promise.reject;
+
+  let then_: (Js.Promise.t('a), 'a => Js.Promise.t('b)) => Js.Promise.t('b) =
+    (promise, fn) => Js.Promise.then_(v => fn(v), promise);
+
+  let catch:
+    (Js.Promise.t('a), Js.Promise.error => Js.Promise.t('a)) =>
+    Js.Promise.t('a) =
+    (promise, fn) => Js.Promise.catch(e => fn(e), promise);
+  let finalize: Js.Promise.t('a) => unit = ignore;
+};

--- a/src/ReasonMLCommunity__ApolloClient.re
+++ b/src/ReasonMLCommunity__ApolloClient.re
@@ -64,6 +64,8 @@ module GraphQL_PPX = {
   type templateTagReturnType = ApolloClient__Graphql.documentNode;
 };
 
+module Promise = ApolloClient__Promise;
+
 /** Convenient access to all types and the methods for working with those types */
 module Types = {
   module ApolloError = ApolloClient__Errors_ApolloError;


### PR DESCRIPTION
### Results of Results
In the last pass I converted all the async stuff to return a `Promise.t(someApolloResult)`, but I immediately realized it's very important that any async promise/monad have a way to bail out of a sequence of computation. So this PR finishes out how I would like promises to work by converting that `someApolloResult` into a proper `Belt.Result.t(nicerApolloResult, ApolloError.t)`. Take for example `FetchResult.t`:
```reason
module FetchResult = {
  ...

  type t__ok('data) = {
    data: 'data,
    error: option(ApolloError.t),
    extensions: option(Js.Json.t),
    context: option(Js.Json.t),
  };

  let toResult: t('data) => Belt.Result.t(t__ok('data), ApolloError.t) =
    fetchResult => {
      switch (fetchResult) {
      | {data: Some(data)} =>
        Ok({
          data,
          error: fetchResult.error,
          extensions: fetchResult.extensions,
          context: fetchResult.context,
        })
      | {error: Some(error)} => Error(error)
      | {data: None, error: None} =>
        Error(
          ApolloError.make(
            ~errorMessage=
              "No data and no error on FetchResult.t. Shouldn't this be impossible?",
            (),
          ),
        )
      };
    };
};
```

The premise of the logic is that **you should always have either data or an error**. If I'm missing something and that's not true, then this whole thing falls down. This transforms three cases of a "result":
- The case that definitely has data and (if you have an error policy of "none" having data does mean success. But you might need error policy of "all" in some rare cases so it still includes optional error property)
- The case of no data and an error (definitely an error result)
- The case of no data and no error which in my mind should be impossible, so it gets elevated to an error result as well

This makes the vast majority of operations safer (I know this implementation would have caught oversights on our app) and easier (data is not optional so you don't have to deal with extra cases!). If you have an error policy of "all" you still have to check for errors when you have data, but this isn't any worse than the current situation and I think is really a minority use-case? I need to look up what is default.

### Js Promises and Ideal Ergonomics
I tried forever to make promises customizable, but every option I tried was terrible. I'm not totally sure, but at this point the most viable option seems to me maintaining two implementations for parts that have promises. :( It was easier for me to work with `reason-promise` while exploring an ideal promise situation, so that's what I've done here. Ultimately, I think `reason-promise` is so vastly superior to `Js.Promise` I'll always maintain my own wrapper at work and in personal projects. I may as well maintain a wrapper in the official library. **The question then becomes, is it worth maintaining a `Js.Promise` implementation?** I'm down to do it, but would like to hear if there's actually demand as well as other thoughts now that we know a little more about the situation. I've added a file of example promise chaining to compare ergonomics to how they used to be. I'll comment on them.

