### PR TITLE
serializeVariables

### DIFF
--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -612,8 +612,6 @@ let make:
           ~update=?,
           variables,
         ) => {
-      let jsVariables =
-        variables->Operation.serializeVariables->mapJsVariables;
       let safeParse = Utils.safeParse(Operation.parse);
 
       Js_.mutate(
@@ -630,10 +628,12 @@ let make:
               updateQueries,
               refetchQueries,
               update,
-              variables: jsVariables,
+              variables,
             },
+            ~mapJsVariables,
             ~safeParse,
             ~serialize=Operation.serialize,
+            ~serializeVariables=Operation.serializeVariables,
           ),
       )
       ->Promise.Js.fromBsPromise
@@ -679,20 +679,22 @@ let make:
           ~mapJsVariables=Utils.identity,
           variables,
         ) => {
-      let jsVariables =
-        variables->Operation.serializeVariables->mapJsVariables;
       let safeParse = Utils.safeParse(Operation.parse);
 
       Js_.query(
         jsClient,
         ~options=
-          QueryOptions.toJs({
-            fetchPolicy,
-            query: Operation.query,
-            variables: jsVariables,
-            errorPolicy,
-            context,
-          }),
+          QueryOptions.toJs(
+            {
+              fetchPolicy,
+              query: Operation.query,
+              variables,
+              errorPolicy,
+              context,
+            },
+            ~mapJsVariables,
+            ~serializeVariables=Operation.serializeVariables,
+          ),
       )
       ->Promise.Js.fromBsPromise
       ->Promise.Js.toResult
@@ -780,20 +782,22 @@ let make:
           ~mapJsVariables=Utils.identity,
           variables,
         ) => {
-      let jsVariables =
-        variables->Operation.serializeVariables->mapJsVariables;
       let safeParse = Utils.safeParse(Operation.parse);
 
       jsClient
       ->Js_.watchQuery(
           ~options=
-            WatchQueryOptions.toJs({
-              fetchPolicy,
-              query: Operation.query,
-              variables: Some(jsVariables),
-              errorPolicy,
-              context,
-            }),
+            WatchQueryOptions.toJs(
+              {
+                fetchPolicy,
+                query: Operation.query,
+                variables,
+                errorPolicy,
+                context,
+              },
+              ~mapJsVariables,
+              ~serializeVariables=Operation.serializeVariables,
+            ),
         )
       ->ObservableQuery.fromJs(~safeParse);
     };

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
@@ -103,11 +103,17 @@ module QueryOptions = {
     context: option(Js.Json.t),
   };
 
-  let toJs: t('jsVariables) => Js_.t('jsVariables) =
-    t => {
+  let toJs:
+    (
+      t('variables),
+      ~mapJsVariables: 'jsVariables => 'jsVariables,
+      ~serializeVariables: 'variables => 'jsVariables
+    ) =>
+    Js_.t('jsVariables) =
+    (t, ~mapJsVariables, ~serializeVariables) => {
       fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
       query: t.query,
-      variables: t.variables,
+      variables: t.variables->serializeVariables->mapJsVariables,
       errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
       context: t.context,
     };
@@ -119,7 +125,8 @@ module WatchQueryOptions = {
       fetchPolicy: option(WatchQueryFetchPolicy.Js_.t),
       // ...extends QueryBaseOptions
       query: Graphql.documentNode,
-      variables: option('jsVariables),
+      // We don't allow optional variables because it's not typesafe
+      variables: 'jsVariables,
       errorPolicy: option(ErrorPolicy.Js_.t),
       context: option(Js.Json.t),
     };
@@ -128,16 +135,22 @@ module WatchQueryOptions = {
   type t('jsVariables) = {
     fetchPolicy: option(WatchQueryFetchPolicy.t),
     query: Graphql.documentNode,
-    variables: option('jsVariables),
+    variables: 'jsVariables,
     errorPolicy: option(ErrorPolicy.t),
     context: option(Js.Json.t),
   };
 
-  let toJs: t('jsVariables) => Js_.t('jsVariables) =
-    t => {
+  let toJs:
+    (
+      t('variables),
+      ~mapJsVariables: 'jsVariables => 'jsVariables,
+      ~serializeVariables: 'variables => 'jsVariables
+    ) =>
+    Js_.t('jsVariables) =
+    (t, ~mapJsVariables, ~serializeVariables) => {
       fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
       query: t.query,
-      variables: t.variables,
+      variables: t.variables->serializeVariables->mapJsVariables,
       errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
       context: t.context,
     };
@@ -365,7 +378,7 @@ module MutationOptions = {
     };
   };
 
-  type t('data, 'jsVariables) = {
+  type t('data, 'variables, 'jsVariables) = {
     context: option(Js.Json.t),
     fetchPolicy: option(FetchPolicy__noCacheExtracted.t),
     mutation: Graphql.documentNode,
@@ -376,17 +389,19 @@ module MutationOptions = {
     refetchQueries: option(RefetchQueryDescription.t),
     update: option(MutationUpdaterFn.t('data)),
     updateQueries: option(MutationQueryReducersMap.t('data)),
-    variables: 'jsVariables,
+    variables: 'variables,
   };
 
   let toJs:
     (
-      t('data, 'jsVariables),
+      t('data, 'variables, 'jsVariables),
+      ~mapJsVariables: 'jsVariables => 'jsVariables,
       ~safeParse: Types.safeParse('data, 'jsData),
-      ~serialize: 'data => 'jsData
+      ~serialize: 'data => 'jsData,
+      ~serializeVariables: 'variables => 'jsVariables
     ) =>
     Js_.t('jsData, 'jsVariables) =
-    (t, ~safeParse, ~serialize) => {
+    (t, ~mapJsVariables, ~safeParse, ~serialize, ~serializeVariables) => {
       awaitRefetchQueries: t.awaitRefetchQueries,
       context: t.context,
       errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
@@ -404,6 +419,6 @@ module MutationOptions = {
       updateQueries:
         t.updateQueries
         ->Belt.Option.map(MutationQueryReducersMap.toJs(~safeParse)),
-      variables: t.variables,
+      variables: t.variables->serializeVariables->mapJsVariables,
     };
 };


### PR DESCRIPTION
`watchQuery` still had optional variables in the type which allows for the dreaded `Some(())` situation when you have no variables. Also I see I missed moving some variables serialization into the `toJs` functions.