### PR TITLE
Extra ApolloError validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,32 +85,33 @@ let make = () => {
 
 Other than some slightly different ergonomics, the underlying functionality is almost identical to the [official Apollo Client 3 docs](https://www.apollographql.com/docs/react/v3.0-beta/get-started/), so that is still a good resource for working with this library.
 
-It's probably worth noting this library leverages records heavily which allows for very similar syntax to working with javascript objects and other benefits, but comes with a downside. You may need to annotate the types if you're using a record in a context where the compiler cannot infer what it is. The most common case is when using a non-T-first api like `Js.Promise`. For this reason we expose every type from the `ApolloClient.Types` module for convenience
-Example:
+It's probably worth noting this library leverages records heavily which allows for very similar syntax to working with javascript objects and other benefits, but comes with a downside. You may need to annotate the types if you're using a record in a context where the compiler cannot infer what it is. The most common case is when using a non-T-first api like `Js.Promise`. For this reason we expose every type from the `ApolloClient.Types` module for convenience. Example:
 
 ```reason
-  /** Inspecting the types reveals this is a QueryResult.t */
   let queryResult = SomeQuery.use();
 
-  /** I can destructure, pattern match, or access properties just like javascript */
+  // I can destructure or access properties just like javascript, and also pattern match!
   switch (queryResult) {
     | {loading: true} =>
-    /** Show loading */
+      // Show loading
     | {data: Some(data), fetchMore} =>
-    let onClick = fetchMore();
-    /** Show data */
+      let onClick = _ => fetchMore();
+      // Show data
   }
 
-  /** Sometimes you need to annotate */
+  // Annotation is necessary in some cases
   apolloClient.query(~query=(module SomeQuery), ())
-  |> Js.Promise.then(result => switch (result) {
+  |> Js.Promise.then(result => // Hover over the type and you can see it is an ApolloQueryResult.t__ok
+    // Let's open the module so the record fields are accessible
+    open ApolloClient.Types.ApolloQueryResult;
+    // ☝️ You don't have to go searching for a type, everything is accessible under ApolloClient.Types
+    switch (result) {
     | Some(apolloQueryResult) =>
-      Js.log2("Got data!", apolloQueryResult.ApolloClient.Types.ApolloQueryResult.data)
-      /** ☝️ Note that once you know the type, you don't have to go searching for it.
-        Everything is accessible under ApolloClient.Types */
+      Js.log2("Got data!", apolloQueryResult.data)
     | Error(_) =>
       Js.log("Check out EXAMPLES/ for T-first promise solutions that don't have this problem!")
-  })
+    }
+  )
 ```
 
 ## Recommended Editor Extensions (Visual Studio Code)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reason-apollo-client",
   "description": "ReasonML / BuckleScript bindings for the Apollo Client ecosystem",
-  "version": "1.0.0-f345e63.0",
+  "version": "1.0.0-beta.0",
   "keywords": [
     "Apollo",
     "BuckleScript",
@@ -18,13 +18,15 @@
   "scripts": {
     "build": "bsb -make-world",
     "clean": "bsb -clean-world",
-    "start": "bsb -make-world -w"
+    "start": "bsb -make-world -w",
+    "test": "jest"
   },
   "devDependencies": {
     "@apollo/client": "^3.1.3",
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "^8.2.0",
     "graphql": "^14.0.0",
+    "jest": "26.5.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "reason-react": "^0.9.1",

--- a/src/@apollo/client/errors/__tests__/ApolloClient__Errors_ApolloError.test.js
+++ b/src/@apollo/client/errors/__tests__/ApolloClient__Errors_ApolloError.test.js
@@ -1,0 +1,24 @@
+const {
+  ensureApolloError,
+} = require("../ApolloClient__Errors_ApolloError.bs").Js_;
+const { ApolloError } = require("@apollo/client");
+console.log(ensureApolloError);
+
+describe("dealing with garbage", () => {
+  it("ignores proper ApolloErrors", () => {
+    let networkError = new Error("This should be preserved");
+    let apolloError = new ApolloError({ networkError });
+    const checkedApolloError = ensureApolloError(apolloError);
+
+    expect(checkedApolloError.networkError).toBe(networkError);
+  });
+
+  it("should intelligently wrap a GrapqhQLError masquerading as ApolloError", () => {
+    const apolloError = ensureApolloError({
+      message: "this is a graphql error",
+      extensions: { code: "some_code" },
+    });
+
+    expect(apolloError.graphQLErrors[0].extensions.code).toBe("some_code");
+  });
+});


### PR DESCRIPTION
`as Any`. Sadly, the types in Apollo Client can't be relied on totally and I've experienced `GraphQLerrors` sneaking into places where I'm destructuring an `ApolloError` when using subscriptions. I made a PR for the issue months back and even scaled it back to almost nothing, but no response: https://github.com/apollographql/apollo-client/pull/6894 Either I'm totally missing something or the team is swamped. 🤷 Anyway, we can deal with it here instead.