### PR TITLE
removed 5 from network status

### DIFF
--- a/src/@apollo/client/core/ApolloClient__Core_NetworkStatus.re
+++ b/src/@apollo/client/core/ApolloClient__Core_NetworkStatus.re
@@ -9,9 +9,9 @@ module NetworkStatus = {
     | [@bs.as 2] SetVariables
     | [@bs.as 3] FetchMore
     | [@bs.as 4] Refetch
-    | [@bs.as 5] Poll
-    | [@bs.as 6] Ready
-    | [@bs.as 7] Error;
+    | [@bs.as 6] Poll
+    | [@bs.as 7] Ready
+    | [@bs.as 8] Error;
 
   let toJs: t => Js_.t = tToJs;
 


### PR DESCRIPTION
I'm using your next branch

I noticed there is no network status of 5.

https://github.com/apollographql/apollo-client/blob/main/docs/shared/query-result.mdx

A number from 1-8 (1 = loading, 2 = setVariables, 3 = fetchMore, 4 = refetch, 6 = poll, 7 = ready, 8 = error) corresponding to the detailed state of your network request. Includes information about refetching and polling status. Used in conjunction with the notifyOnNetworkStatusChange prop.

Thanks for your work