### PR TITLE
Added failing example of polymorphic variant from ReadFragment

### DIFF
--- a/EXAMPLES/src/App.re
+++ b/EXAMPLES/src/App.re
@@ -18,5 +18,7 @@ let make = () => {
     <ClientBasics />
     <h2> "Fragments"->React.string </h2>
     <Query_Fragments />
+    <h2> "Unions"->React.string </h2>
+    <Query_Unions />
   </ApolloClient.React.ApolloProvider>;
 };

--- a/EXAMPLES/src/fragmentsUsage/Query_Fragments.re
+++ b/EXAMPLES/src/fragmentsUsage/Query_Fragments.re
@@ -27,7 +27,8 @@ module TodoCount = {
 [@react.component]
 let make = () => {
   let queryResult = TodosQuery.use();
-
+  Js.log("queryResult");
+  Js.log(queryResult);
   <div>
     {switch (queryResult) {
      | {loading: true, data: None} => <p> "Loading"->React.string </p>

--- a/EXAMPLES/src/fragmentsUsage/Query_Unions.re
+++ b/EXAMPLES/src/fragmentsUsage/Query_Unions.re
@@ -48,6 +48,10 @@ module TicketResultsComp = {
           Js.log(ticketField);
           <p>{ReasonReact.string("Future!!")}</p>
         }
+        | _ => {
+          Js.log("Everything else... shouldn't get here");
+          <p>{ReasonReact.string("Something's wrong")}</p>
+        }
         }
       }
     </div>;

--- a/EXAMPLES/src/fragmentsUsage/Query_Unions.re
+++ b/EXAMPLES/src/fragmentsUsage/Query_Unions.re
@@ -1,0 +1,89 @@
+// The TodosQuery below is going to look for a module of the same name to define the fragment
+module TicketFields = Union_Fragment.TicketFields;
+
+module TicketQuery = [%graphql
+  {|
+    query TicketQuery {
+      tickets (limit: 6, offset: 0)  {
+        results {
+          ...TicketFields
+        }
+      }
+    }
+  |}
+];
+
+// It's easy to share types when using Fragments
+module TicketResultsComp = {
+  [@react.component]
+  let make = (~result: TicketFields.t) => {
+    
+    let ticketField = Client.instance.readFragment(
+      ~fragment=(module Union_Fragment.TicketFields),
+      ~id="Ticket" ++ ":" ++ result.id,
+      ~fragmentName=("TicketFields"),
+      (),
+    );
+
+    Js.log("ticketField");
+    Js.log(ticketField);
+
+    <div>
+      {
+        switch(ticketField){
+        | None => <p>{ReasonReact.string("No Result")}</p>
+        | Some({assignee: None}) => <p>{ReasonReact.string("No Result")}</p>
+        | Some({assignee: Some(`User(user))}) => {
+          Js.log("User");
+          Js.log(user);
+          <p>{ReasonReact.string("My Name is " ++ user.fullName)}</p>
+        }
+        | Some({assignee: Some(`WorkingGroup(workingGroup))}) => {
+          Js.log("WorkingGroup");
+          Js.log(workingGroup);
+          <p>{ReasonReact.string("My dbId is " ++ workingGroup.dbId)}</p>
+        }
+        | Some({assignee: Some(`FutureAddedValue(_))}) => {
+          Js.log("FutureAddedValue");
+          Js.log(ticketField);
+          <p>{ReasonReact.string("Future!!")}</p>
+        }
+        }
+      }
+    </div>;
+  };
+};
+
+[@react.component]
+let make = () => {
+  let queryResult = TicketQuery.use();
+
+  Js.log("queryResult");
+  Js.log(queryResult);
+
+  <div>
+    {switch (queryResult) {
+     | {loading: true, data: None} => <p> "Loading"->React.string </p>
+     | {loading, data: Some({tickets}), error} =>
+       <>
+         <dialog>
+           {loading ? <p> "Refreshing..."->React.string </p> : React.null}
+           {switch (error) {
+            | Some(_) =>
+              <p>
+                "Something went wrong, data may be incomplete"->React.string
+              </p>
+            | None => React.null
+            }}
+         </dialog>
+          {
+            tickets.results
+            |> Belt.Array.map(_, res => <TicketResultsComp key=res.id result=res />)
+            |> ReasonReact.array
+          }
+       </>
+     | {loading: false, data: None} =>
+       <p> "Error loading data"->React.string </p>
+     }}
+  </div>;
+};

--- a/EXAMPLES/src/fragmentsUsage/Union_Fragment.re
+++ b/EXAMPLES/src/fragmentsUsage/Union_Fragment.re
@@ -1,0 +1,34 @@
+module UserFields = [%graphql
+  {|
+    fragment UserFields on User {
+      id
+      avatarUrl
+      fullName
+    }
+  |};
+];
+
+module WorkingGroupFields = [%graphql
+  {|
+    fragment WorkingGroupFields on WorkingGroup {
+      id
+      dbId
+    }
+  |};
+];
+
+module TicketFields = [%graphql
+  {|
+    fragment TicketFields on Ticket {
+      id
+      assignee {
+        ... on User {
+          ...UserFields
+        }
+        ... on WorkingGroup {
+          ...WorkingGroupFields
+        }
+      }
+    }
+  |};
+];


### PR DESCRIPTION
In one of my projects, I'm using `readFragment` often to access fragment data throughout the frontend.  

I made a small example of getting `readFragment` data after a query.  This code currently fails receiving a null for `match.NAME`.