### PR TITLE
Parse readFragment result

### DIFF
--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -760,7 +760,8 @@ let make:
           ~optimistic?,
           (),
         )
-      ->Js.toOption;
+      ->Js.toOption
+      ->Belt.Option.map(Fragment.parse);
     };
 
     let readQuery =

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.re
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.re
@@ -170,7 +170,8 @@ module ApolloCache = {
             ~optimistic?,
             (),
           )
-        ->Js.toOption;
+        ->Js.toOption
+        ->Belt.Option.map(Fragment.parse);
       };
 
       let readQuery =


### PR DESCRIPTION
Missed parsing this completely somehow. These are not converting exceptions to result either. I'll do that in a next PR because I want to think about what shape it should take. `Some(Ok(data))`? Not super great.