### PR TITLE
Cache parse result

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@apollo/client": "^3.1.3",
     "@reasonml-community/graphql-ppx": "^1.0.0",
-    "bs-platform": "^8.2.0",
+    "bs-platform": "8.4.2",
     "graphql": "^14.0.0",
     "jest": "26.5.3",
     "react": "^16.13.1",

--- a/src/@apollo/client/ApolloClient__ApolloClient.re
+++ b/src/@apollo/client/ApolloClient__ApolloClient.re
@@ -455,7 +455,7 @@ type t = {
       ~fragmentName: string=?,
       unit
     ) =>
-    option('data),
+    option(Types.parseResult('data)),
 
   [@bs.as "reason_readQuery"]
   readQuery:
@@ -470,7 +470,7 @@ type t = {
       ~optimistic: bool=?,
       'variables
     ) =>
-    option('data),
+    option(Types.parseResult('data)),
 
   [@bs.as "reason_resetStore"]
   resetStore:
@@ -754,6 +754,8 @@ let make:
           ~fragmentName=?,
           (),
         ) => {
+      let safeParse = Utils.safeParse(Fragment.parse);
+
       jsClient
       ->Js_.readFragment(
           ~options={id, fragment: Fragment.query, fragmentName},
@@ -761,7 +763,7 @@ let make:
           (),
         )
       ->Js.toOption
-      ->Belt.Option.map(Fragment.parse);
+      ->Belt.Option.map(safeParse);
     };
 
     let readQuery =
@@ -780,6 +782,8 @@ let make:
           ~optimistic=?,
           variables,
         ) => {
+      let safeParse = Utils.safeParse(Operation.parse);
+
       Js_.readQuery(
         jsClient,
         ~options=
@@ -791,7 +795,7 @@ let make:
         ~optimistic,
       )
       ->Js.toOption
-      ->Belt.Option.map(Operation.parse);
+      ->Belt.Option.map(safeParse);
     };
 
     let resetStore:

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.re
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.re
@@ -92,7 +92,7 @@ module ApolloCache = {
         ~fragmentName: string=?,
         unit
       ) =>
-      option('data),
+      option(Types.parseResult('data)),
 
     [@bs.as "reason_readQuery"]
     readQuery:
@@ -107,7 +107,7 @@ module ApolloCache = {
         ~optimistic: bool=?,
         'variables
       ) =>
-      option('data),
+      option(Types.parseResult('data)),
 
     [@bs.as "reason_writeFragment"]
     writeFragment:
@@ -164,6 +164,8 @@ module ApolloCache = {
             ~fragmentName=?,
             (),
           ) => {
+        let safeParse = Utils.safeParse(Fragment.parse);
+
         js
         ->Js_.readFragment(
             ~options={id, fragment: Fragment.query, fragmentName},
@@ -171,7 +173,7 @@ module ApolloCache = {
             (),
           )
         ->Js.toOption
-        ->Belt.Option.map(Fragment.parse);
+        ->Belt.Option.map(safeParse);
       };
 
       let readQuery =
@@ -190,6 +192,8 @@ module ApolloCache = {
             ~optimistic=?,
             variables,
           ) => {
+        let safeParse = Utils.safeParse(Operation.parse);
+
         js
         ->Js_.readQuery(
             ~options=
@@ -201,7 +205,7 @@ module ApolloCache = {
             ~optimistic,
           )
         ->Js.toOption
-        ->Belt.Option.map(Operation.parse);
+        ->Belt.Option.map(safeParse);
       };
 
       let writeFragment =

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.re
@@ -134,8 +134,8 @@ module ObservableQuery = {
     (js, ~safeParse) => {
       let parseWithOnErrorCall = (jsData, onError) =>
         switch (safeParse(jsData)) {
-        | Data(data) => Some(data)
-        | ParseError({error}) =>
+        | Ok(data) => Some(data)
+        | Error({error}) =>
           onError(error);
           None;
         };

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.re
@@ -209,15 +209,15 @@ module UpdateQueryFn = {
     ) =>
       (. jsQueryData, {subscriptionData: {data}}) =>
         switch (jsQueryData->querySafeParse, data->subscriptionSafeParse) {
-        | (Data(queryData), Data(subscriptionData)) =>
+        | (Ok(queryData), Ok(subscriptionData)) =>
           t(queryData, {
                          subscriptionData: {
                            data: subscriptionData,
                          },
                        })
           ->querySerialize
-        | (ParseError(parseError), _)
-        | (_, ParseError(parseError)) =>
+        | (Error(parseError), _)
+        | (_, Error(parseError)) =>
           onParseError(parseError);
           jsQueryData;
         };

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.re
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.re
@@ -452,7 +452,7 @@ module QueryResult = {
                       jsFetchMoreOptions.fetchMoreResult
                       ->Belt.Option.map(safeParse),
                     ) {
-                    | (Data(previousResult), Some(Data(fetchMoreResult))) =>
+                    | (Ok(previousResult), Some(Ok(fetchMoreResult))) =>
                       updateQuery(
                         previousResult,
                         {
@@ -461,7 +461,7 @@ module QueryResult = {
                         },
                       )
                       ->serialize
-                    | (Data(previousResult), None) =>
+                    | (Ok(previousResult), None) =>
                       updateQuery(
                         previousResult,
                         {
@@ -470,10 +470,10 @@ module QueryResult = {
                         },
                       )
                       ->serialize
-                    | (ParseError(parseError), _)
-                    | (Data(_), Some(ParseError(parseError))) =>
+                    | (Error(parseError), _)
+                    | (Ok(_), Some(Error(parseError))) =>
                       parseErrorDuringCall.contents =
-                        Some(ParseError(parseError));
+                        Some(Error(parseError));
                       previousResult;
                     };
                   }
@@ -489,7 +489,7 @@ module QueryResult = {
             jsApolloQueryResult =>
               Js.Promise.resolve(
                 switch (parseErrorDuringCall.contents) {
-                | Some(ParseError(parseError)) =>
+                | Some(Error(parseError)) =>
                   Error(
                     ApolloError.make(
                       ~networkError=ParseError(parseError),

--- a/src/ApolloClient__Types.re
+++ b/src/ApolloClient__Types.re
@@ -33,12 +33,10 @@ module type OperationNoRequiredVars = {
 };
 
 type parseError = {
-  jsData: Js.Json.t,
+  value: Js.Json.t,
   error: Js.Exn.t,
 };
 
-type parseResult('data) =
-  | Data('data)
-  | ParseError(parseError);
+type parseResult('data) = result('data, parseError);
 
 type safeParse('data, 'jsData) = 'jsData => parseResult('data);

--- a/src/ApolloClient__Utils.re
+++ b/src/ApolloClient__Utils.re
@@ -35,9 +35,9 @@ external asJson: 'any => Js.Json.t = "%identity";
 let safeParse: ('jsData => 'data) => Types.safeParse('data, 'jsData) =
   (parse, jsData) =>
     switch (parse(jsData)) {
-    | data => Data(data)
+    | data => Ok(data)
     | exception (Js.Exn.Error(error)) =>
-      ParseError({jsData: jsData->asJson, error})
+      Error({value: jsData->asJson, error})
     };
 
 let safeParseAndLiftToCommonResultProps:
@@ -58,7 +58,7 @@ let safeParseAndLiftToCommonResultProps:
       };
 
     switch (jsData->Belt.Option.map(jsData => safeParse(jsData))) {
-    | Some(ParseError(parseError)) =>
+    | Some(Error(parseError)) =>
       // Be careful we do not overwrite an existing error with a ParseError
       existingError->Belt.Option.isSome
         ? (None, existingError)
@@ -72,7 +72,7 @@ let safeParseAndLiftToCommonResultProps:
             ),
           ),
         )
-    | Some(Data(data)) => (Some(data), existingError)
+    | Some(Ok(data)) => (Some(data), existingError)
     | None => (None, existingError)
     };
   };


### PR DESCRIPTION
At some point, I wanted to statically differentiate between a parse result and some other sort of result to help with some conversions and I guess I just forgot to do the last step. Anyway, there are few places where the `parseResult` variant is exposed. This switches to regular results.

Also, the `readFragment` and `readQuery` methods were still throwing exceptions from parse. This fixes that so they now return an optional result.